### PR TITLE
Resolving issue with custom post type and preview link being generate…

### DIFF
--- a/wp-permastructure.php
+++ b/wp-permastructure.php
@@ -337,7 +337,7 @@ class wp_permastructure {
 			$permalink = home_url( str_replace($rewritecode, $rewritereplace, $permalink) );
 			$permalink = user_trailingslashit($permalink, 'single');
 		} else { // if they're not using the fancy permalink option
-			$permalink = home_url('?p=' . $post->ID);
+			$permalink = home_url('?post_type='.$post->post_type.'&p=' . $post->ID);
 		}
 
 		return $permalink;


### PR DESCRIPTION
Ran into an issue where the Preview link was not being generated correctly for permalinks - seems to be a very rare corner case issue.

CPT with Taxonomy was set up as: CPTNAME/%TAXONOMY%/%POSTNAME%

Before a Draft is saved the url was coming up as /?p=ID which was giving a 404, by adding in the post type to the url it prevents this from happening.