### PR TITLE
WordPress SEO (YoastSEO) compatibility

### DIFF
--- a/wp-permastructure.php
+++ b/wp-permastructure.php
@@ -241,7 +241,7 @@ class wp_permastructure {
 	 *
 	 * @return string    The parsed permalink
 	 */
-	public function parse_permalinks( $post_link, WP_Post $post, $leavename, $sample = false ) {
+	public function parse_permalinks( $post_link, $post, $leavename, $sample = false ) {
 
 		// Make a stupid request and we'll do nothing.
 		if ( !post_type_exists( $post->post_type ) )


### PR DESCRIPTION
When calling `get_permalink()` with stdClass as first parameter (eg. a post retrieved by `$wpdb->get_results()`), following error occurs:
```
Catchable fatal error: Argument 2 passed to wp_permastructure::parse_permalinks() must be an instance of WP_Post, instance of stdClass given
```
In result, when WordPress SEO plugin was active, there was an error while generating sitemaps (500 Internal Server Error). This pull request fixes this issue.