### PR TITLE
Downstream updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "humanmade/wp-permastructure",
+    "description": "Post type rewrite features for WordPress",
+    "type": "wordpress-plugin",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "Robert O'Rourke",
+            "email": "rob@humanmade.com"
+        }
+    ],
+    "require": {}
+}

--- a/wp-permastructure.php
+++ b/wp-permastructure.php
@@ -293,7 +293,11 @@ class wp_permastructure {
 				if ( strpos($permalink, '%'. $taxonomy .'%') !== false ) {
 					$terms = get_the_terms( $post->ID, $taxonomy );
 					if ( $terms ) {
-						usort($terms, '_usort_terms_by_ID'); // order by ID
+                        if( function_exists( 'wp_list_sort' ) ) {
+                            $terms = wp_list_sort( $terms, 'term_id', 'ASC' );  // order by term_id ASC
+                        } else {
+                            usort( $terms, '_usort_terms_by_ID' ); // order by term_id ASC
+                        }
 
 						/**
 						 * Filter the term that gets used in the `$tax` permalink token.

--- a/wp-permastructure.php
+++ b/wp-permastructure.php
@@ -300,10 +300,10 @@ class wp_permastructure {
 				if ( strpos($permalink, '%'. $taxonomy .'%') !== false ) {
 					$terms = get_the_terms( $post->ID, $taxonomy );
 					if ( $terms ) {
-						if( function_exists( 'wp_list_sort' ) ) {
-						    $terms = wp_list_sort( $terms, 'term_id', 'ASC' );  // order by term_id ASC
+						if ( function_exists( 'wp_list_sort' ) ) {
+							$terms = wp_list_sort( $terms, 'term_id', 'ASC' );  // order by term_id ASC
 						} else {
-						    usort( $terms, '_usort_terms_by_ID' ); // order by term_id ASC
+							usort( $terms, '_usort_terms_by_ID' ); // order by term_id ASC
 						}
 
 						/**

--- a/wp-permastructure.php
+++ b/wp-permastructure.php
@@ -3,7 +3,7 @@
 Plugin Name: WP Permastructure
 Plugin URI: https://github.com/interconnectit/wp-permastructure
 Description: Adds the ability to define permalink structures for any custom post type using rewrite tags.
-Version: 1.4.3
+Version: 1.4.4
 Author: Robert O'Rourke
 Author URI: http://interconnectit.com
 License: GPLv2 or later
@@ -19,9 +19,9 @@ License: GPLv2 or later
  * eg:
  *
  * register_post_type( 'my_type', array(
- * 		...
- * 		'rewrite' => array( 'permastruct' => '/%custom_taxonomy%/%author%/%postname%/' ),
- *  	...
+ *        ...
+ *        'rewrite' => array( 'permastruct' => '/%custom_taxonomy%/%author%/%postname%/' ),
+ *    ...
  * ) );
  *
  * Alternatively you can set the permalink structure from the permalinks settings page
@@ -38,368 +38,404 @@ License: GPLv2 or later
  * 1.0: Initial import
  */
 
-if ( ! class_exists( 'wp_permastructure' ) ) {
+if ( !class_exists( 'wp_permastructure' ) ) {
 
-add_action( 'init', array( 'wp_permastructure', 'instance' ), 0 );
+    add_action( 'init', array( 'wp_permastructure', 'instance' ), 0 );
 
-class wp_permastructure {
+    class wp_permastructure {
 
-	public $settings_section = 'wp_permastructure';
+        public $settings_section = 'wp_permastructure';
 
-	/**
-	 * @var protect endpoints from being vaped if a category/tag slug is set
-	 */
-	protected $endpoints;
+        /**
+         * @var protect endpoints from being vaped if a category/tag slug is set
+         */
+        protected $endpoints;
 
-	/**
-	 * Reusable object instance.
-	 *
-	 * @type object
-	 */
-	protected static $instance = null;
+        /**
+         * Reusable object instance.
+         *
+         * @type object
+         */
+        protected static $instance = null;
 
-	/**
-	 * Creates a new instance. Called on 'init'.
-	 * May be used to access class methods from outside.
-	 *
-	 * @see    __construct()
-	 * @return void
-	 */
-	public static function instance() {
-		null === self :: $instance AND self :: $instance = new self;
-		return self :: $instance;
-	}
+        /**
+         * Creates a new instance. Called on 'init'.
+         * May be used to access class methods from outside.
+         *
+         * @see    __construct()
+         * @return void
+         */
+        public static function instance() {
+            null === self:: $instance AND self:: $instance = new self;
 
-
-	public function __construct() {
-
-		// Late init to protect endpoints
-		add_action( 'init', array( $this, 'late_init' ), 999 );
-
-		// Settings fields on permalinks page
-		add_action( 'admin_init', array( $this, 'admin_init' ) );
-
-		// add our new peramstructs to the rewrite rules
-		add_filter( 'post_rewrite_rules', array( $this, 'add_permastructs' ) );
-
-		// parse the generated links - enable custom taxonomies for built in post links
-		add_filter( 'post_link', array( $this, 'parse_permalinks' ), 10, 3 );
-		add_filter( 'post_type_link', array( $this, 'parse_permalinks' ), 10, 4 );
-
-		// that's it!
-
-	}
+            return self:: $instance;
+        }
 
 
-	public function late_init() {
-		global $wp_rewrite;
-		$this->endpoints = $wp_rewrite->endpoints;
-	}
+        public function __construct() {
+
+            // Late init to protect endpoints
+            add_action( 'init', array( $this, 'late_init' ), 999 );
+
+            // Settings fields on permalinks page
+            add_action( 'admin_init', array( $this, 'admin_init' ) );
+
+            // add our new peramstructs to the rewrite rules
+            add_filter( 'post_rewrite_rules', array( $this, 'add_permastructs' ) );
+
+            // parse the generated links - enable custom taxonomies for built in post links
+            add_filter( 'post_link', array( $this, 'parse_permalinks' ), 10, 3 );
+            add_filter( 'post_type_link', array( $this, 'parse_permalinks' ), 10, 4 );
+
+            // that's it!
+
+        }
 
 
-	/**
-	 * Add the settings UI
-	 */
-	public function admin_init() {
-
-		add_settings_section(
-			$this->settings_section,
-			__( 'Custom post type permalink settings' ),
-			array( $this, 'settings_section' ),
-			'permalink'
-		);
-
-		foreach( get_post_types( array( '_builtin' => false, 'public' => true ), 'objects' ) as $type ) {
-			$id = $type->name . '_permalink_structure';
-
-			register_setting( 'permalink', $id, array( $this, 'sanitize_permalink' ) );
-			add_settings_field(
-				$id,
-				__( $type->label . ' permalink structure' ),
-				array( $this, 'permalink_field' ),
-				'permalink',
-				$this->settings_section,
-				array( 'id' => $id )
-			);
-		}
-
-	}
+        public function late_init() {
+            global $wp_rewrite;
+            $this->endpoints = $wp_rewrite->endpoints;
+        }
 
 
-	public function settings_section() {
+        /**
+         * Add the settings UI
+         */
+        public function admin_init() {
 
-	}
+            add_settings_section(
+                $this->settings_section,
+                __( 'Custom post type permalink settings' ),
+                array( $this, 'settings_section' ),
+                'permalink'
+            );
 
+            foreach ( get_post_types( array( '_builtin' => false, 'public' => true ), 'objects' ) as $type ) {
+                $id = $type->name . '_permalink_structure';
 
-	public function permalink_field( $args ) {
-		echo '<input type="text" class="regular-text code" value="' . esc_attr( get_option( $args[ 'id' ] ) ) . '" id="' . $args[ 'id' ] . '" name="' . $args[ 'id' ] . '" />';
-	}
+                register_setting( 'permalink', $id, array( $this, 'sanitize_permalink' ) );
+                add_settings_field(
+                    $id,
+                    __( $type->label . ' permalink structure' ),
+                    array( $this, 'permalink_field' ),
+                    'permalink',
+                    $this->settings_section,
+                    array( 'id' => $id )
+                );
+            }
 
-
-	/**
-	 * Runs a simple sanitisation of the custom post type permalink structures
-	 * and adds an error if no post ID or post name present
-	 *
-	 * @param string $permalink The permalink structure
-	 *
-	 * @return string    Sanitised permalink structure
-	 */
-	public function sanitize_permalink( $permalink ) {
-		if ( ! empty( $permalink ) && ! preg_match( '/%(post_id|postname)%/', $permalink ) )
-			add_settings_error( 'permalink_structure', 10, __( 'Permalink structures must contain at least the <code>%post_id%</code> or <code>%postname%</code>.' ) );
-
-		$filtered = wp_check_invalid_utf8( $permalink );
-
-		if ( strpos($filtered, '<') !== false ) {
-			$filtered = wp_pre_kses_less_than( $filtered );
-			// This will strip extra whitespace for us.
-			$filtered = wp_strip_all_tags( $filtered, true );
-		} else {
-			$filtered = trim( preg_replace('/[\r\n\t ]+/', ' ', $filtered) );
-		}
-
-		return preg_replace( '/[^a-zA-Z0-9\/\%_-]*/', '', $filtered );
-	}
+        }
 
 
-	/**
-	 * This function removes unnecessary rules and adds in the new rules
-	 *
-	 * @param array $rules The rewrite rules array for post permalinks
-	 *
-	 * @return array    The modified rules array
-	 */
-	public function add_permastructs( $rules ) {
-		global $wp_rewrite;
+        public function settings_section() {
 
-		// restore endpoints
-		if ( empty( $wp_rewrite->endpoints ) && ! empty( $this->endpoints ) )
-			$wp_rewrite->endpoints = $this->endpoints;
-
-		$permastruct = $wp_rewrite->permalink_structure;
-		$permastructs = array( $permastruct => array( 'post' ) );
-
-		// force page rewrite to bottom
-		$wp_rewrite->use_verbose_page_rules = false;
-
-		// get permastructs foreach custom post type and group any that use the same struct
-		foreach( get_post_types( array( '_builtin' => false, 'public' => true ), 'objects' ) as $type ) {
-			// add/override the custom permalink structure if set in options
-			$post_type_permastruct = get_option( $type->name . '_permalink_structure' );
-			if ( $post_type_permastruct && ! empty( $post_type_permastruct ) ) {
-				if ( ! is_array( $type->rewrite ) )
-					$type->rewrite = array();
-				$type->rewrite[ 'permastruct' ] = $post_type_permastruct;
-			}
-
-			// check we have a custom permalink structure
-			if ( ! is_array( $type->rewrite ) || ! isset( $type->rewrite[ 'permastruct' ] ) )
-				continue;
-
-			// remove default struct rules
-			add_filter( $type->name . '_rewrite_rules', create_function( '$rules', 'return array();' ), 11 );
-
-			if ( ! isset( $permastructs[ $type->rewrite[ 'permastruct' ] ] ) )
-				$permastructs[ $type->rewrite[ 'permastruct' ] ] = array();
-
-			$permastructs[ $type->rewrite[ 'permastruct' ] ][] = $type->name;
-		}
-
-		$rules = array();
-
-		// add our permastructs scoped to the post types - overwriting any keys that already exist
-		foreach( $permastructs as $struct => $post_types ) {
-
-			// if a struct is %postname% only then we need page rules first - if not found wp tries again with later rules
-			if ( preg_match( '/^\/?%postname%\/?$/', $struct ) )
-				$wp_rewrite->use_verbose_page_rules = true;
-
-			// get rewrite rules without walking dirs
-			$post_type_rules_temp = $wp_rewrite->generate_rewrite_rules( $struct, EP_PERMALINK, false, true, false, false, true );
-			foreach( $post_type_rules_temp as $regex => $query ) {
-				if ( preg_match( '/(&|\?)(cpage|attachment|p|name|pagename)=/', $query ) ) {
-					$post_type_query = ( count( $post_types ) < 2 ? '&post_type=' . $post_types[ 0 ] : '&post_type[]=' . join( '&post_type[]=', array_unique( $post_types ) ) );
-					$rules[ $regex ] = $query . ( preg_match( '/(&|\?)(attachment|pagename)=/', $query ) ? '' : $post_type_query );
-				} else
-					unset( $rules[ $regex ] );
-			}
-
-		}
-
-		return $rules;
-	}
+        }
 
 
-	/**
-	 * Generic version of standard permalink parsing function. Adds support for
-	 * custom taxonomies as well as the standard %author% etc...
-	 *
-	 * @param string $post_link             The post URL
-	 * @param WP_Post|object|int|null $post The post object
-	 * @param bool $leavename               Passed to pre_post_link filter
-	 * @param bool $sample                  Used in admin if generating an example permalink
-	 *
-	 * @return string The parsed permalink
-	 */
-	public function parse_permalinks( $post_link, $post, $leavename, $sample = false ) {
-		// Ensure WP_Post object. Some plugins pass arbitrary objects or other data.
-		$post = get_post( $post );
+        public function permalink_field( $args ) {
+            echo '<input type="text" class="regular-text code" value="' . esc_attr( get_option( $args[ 'id' ] ) ) . '" id="' . $args[ 'id' ] . '" name="' . $args[ 'id' ] . '" />';
+        }
 
-		// Only bail if the above get_post() didn't work.
-		if ( ! $post instanceof WP_Post ) {
-			return $post_link;
-		}
 
-		// Make a stupid request and we'll do nothing.
-		if ( !post_type_exists( $post->post_type ) )
-			return $post_link;
+        /**
+         * Runs a simple sanitisation of the custom post type permalink structures
+         * and adds an error if no post ID or post name present
+         *
+         * @param string $permalink The permalink structure
+         *
+         * @return string    Sanitised permalink structure
+         */
+        public function sanitize_permalink( $permalink ) {
+            if ( !empty( $permalink ) && !preg_match( '/%(post_id|postname)%/', $permalink ) ) {
+                add_settings_error( 'permalink_structure', 10, __( 'Permalink structures must contain at least the <code>%post_id%</code> or <code>%postname%</code>.' ) );
+            }
 
-		$rewritecode = array(
-			'%year%',
-			'%monthnum%',
-			'%day%',
-			'%hour%',
-			'%minute%',
-			'%second%',
-			$leavename? '' : '%postname%',
-			'%post_id%',
-			'%author%',
-			$leavename? '' : '%pagename%',
-		);
+            $filtered = wp_check_invalid_utf8( $permalink );
 
-		$taxonomies = get_object_taxonomies( $post->post_type );
+            if ( strpos( $filtered, '<' ) !== false ) {
+                $filtered = wp_pre_kses_less_than( $filtered );
+                // This will strip extra whitespace for us.
+                $filtered = wp_strip_all_tags( $filtered, true );
+            }
+            else {
+                $filtered = trim( preg_replace( '/[\r\n\t ]+/', ' ', $filtered ) );
+            }
 
-		foreach( $taxonomies as $taxonomy )
-			$rewritecode[] = '%' . $taxonomy . '%';
+            return preg_replace( '/[^a-zA-Z0-9\/\%\._-]*/', '', $filtered );
+        }
 
-		if ( is_object($post) && isset($post->filter) && 'sample' == $post->filter )
-			$sample = true;
 
-		$post_type = get_post_type_object( $post->post_type );
-		$permastruct = get_option( $post_type->name . '_permalink_structure' );
+        /**
+         * This function removes unnecessary rules and adds in the new rules
+         *
+         * @param array $rules The rewrite rules array for post permalinks
+         *
+         * @return array    The modified rules array
+         */
+        public function add_permastructs( $rules ) {
+            global $wp_rewrite;
 
-		// prefer option over default
-		if ( $permastruct && ! empty( $permastruct ) ) {
-			$permalink = $permastruct;
-		} elseif ( isset( $post_type->rewrite[ 'permastruct' ] ) && ! empty( $post_type->rewrite[ 'permastruct' ] ) ) {
-			$permalink = $post_type->rewrite[ 'permastruct' ];
-		} else {
-			return $post_link;
-		}
+            // restore endpoints
+            if ( empty( $wp_rewrite->endpoints ) && !empty( $this->endpoints ) ) {
+                $wp_rewrite->endpoints = $this->endpoints;
+            }
 
-		$permalink = apply_filters('pre_post_link', $permalink, $post, $leavename);
+            $permastruct = $wp_rewrite->permalink_structure;
+            $permastructs = array( $permastruct => array( 'post' ) );
 
-		if ( '' != $permalink && !in_array($post->post_status, array('draft', 'pending', 'auto-draft')) ) {
-			$unixtime = strtotime($post->post_date);
+            // force page rewrite to bottom
+            $wp_rewrite->use_verbose_page_rules = false;
 
-			// add ability to use any taxonomies in post type permastruct
-			$replace_terms = array();
-			foreach( $taxonomies as $taxonomy ) {
-				$term = '';
-				$taxonomy_object = get_taxonomy( $taxonomy );
-				if ( strpos($permalink, '%'. $taxonomy .'%') !== false ) {
-					$terms = get_the_terms( $post->ID, $taxonomy );
-					if ( $terms ) {
-						if ( function_exists( 'wp_list_sort' ) ) {
-							$terms = wp_list_sort( $terms, 'term_id', 'ASC' );  // order by term_id ASC
-						} else {
-							usort( $terms, '_usort_terms_by_ID' ); // order by term_id ASC
+            // get permastructs foreach custom post type and group any that use the same struct
+            foreach ( get_post_types( array( '_builtin' => false, 'public' => true ), 'objects' ) as $type ) {
+                // add/override the custom permalink structure if set in options
+                $post_type_permastruct = get_option( $type->name . '_permalink_structure' );
+                if ( $post_type_permastruct && !empty( $post_type_permastruct ) ) {
+                    if ( !is_array( $type->rewrite ) ) {
+                        $type->rewrite = array();
+                    }
+                    $type->rewrite[ 'permastruct' ] = $post_type_permastruct;
+                }
+
+                // check we have a custom permalink structure
+                if ( !is_array( $type->rewrite ) || !isset( $type->rewrite[ 'permastruct' ] ) ) {
+                    continue;
+                }
+
+                // remove default struct rules
+                add_filter( $type->name . '_rewrite_rules', function( $rules ) {
+                    return array();
+                }, 11 );
+
+                if ( !isset( $permastructs[ $type->rewrite[ 'permastruct' ] ] ) ) {
+                    $permastructs[ $type->rewrite[ 'permastruct' ] ] = array();
+                }
+
+                $permastructs[ $type->rewrite[ 'permastruct' ] ][] = $type->name;
+            }
+
+            $rules = array();
+
+            // add our permastructs scoped to the post types - overwriting any keys that already exist
+            foreach ( $permastructs as $struct => $post_types ) {
+
+                // if a struct is %postname% only then we need page rules first - if not found wp tries again with later rules
+                if ( preg_match( '/^\/?%postname%\/?$/', $struct ) ) {
+                    $wp_rewrite->use_verbose_page_rules = true;
+                }
+
+                // get rewrite rules without walking dirs
+                $post_type_rules_temp = $wp_rewrite->generate_rewrite_rules( $struct, EP_PERMALINK, false, true, false, false, true );
+                foreach ( $post_type_rules_temp as $regex => $query ) {
+                    if ( preg_match( '/(&|\?)(cpage|attachment|p|name|pagename)=/', $query ) ) {
+                        $post_type_query = ( count( $post_types ) < 2 ? '&post_type=' . $post_types[ 0 ] : '&post_type[]=' . join( '&post_type[]=', array_unique( $post_types ) ) );
+                        $rules[ $regex ] = $query . ( preg_match( '/(&|\?)(attachment|pagename)=/', $query ) ? '' : $post_type_query );
+                        // Ensure permalinks that match a custom taxonomy path don't get swallowed.
+                        $wp_rewrite->extra_rules_top[ $regex ] = $rules[ $regex ];
+                    }
+                    else {
+                        unset( $rules[ $regex ] );
+                    }
+                }
+
+            }
+
+            return $rules;
+        }
+
+
+        /**
+         * Generic version of standard permalink parsing function. Adds support for
+         * custom taxonomies as well as the standard %author% etc...
+         *
+         * @param string  $post_link The post URL
+         * @param WP_Post $post The post object
+         * @param bool    $leavename Passed to pre_post_link filter
+         * @param bool    $sample Used in admin if generating an example permalink
+         *
+         * @return string    The parsed permalink
+         */
+        public function parse_permalinks( $post_link, $post, $leavename, $sample = false ) {
+            // Yoast Sitemap plug-in doesn't pass a WP_Post object causing a fatal, so we'll check for it and return.
+            if ( !is_a( $post, 'WP_Post' ) ) {
+                return $post_link;
+            }
+
+            // Make a stupid request and we'll do nothing.
+            if ( !post_type_exists( $post->post_type ) ) {
+                return $post_link;
+            }
+
+            $rewritecode = array(
+                '%year%',
+                '%monthnum%',
+                '%day%',
+                '%hour%',
+                '%minute%',
+                '%second%',
+                $leavename ? '' : '%postname%',
+                '%post_id%',
+                '%author%',
+                $leavename ? '' : '%pagename%',
+            );
+
+            $taxonomies = get_object_taxonomies( $post->post_type );
+
+            foreach ( $taxonomies as $taxonomy ) {
+                $rewritecode[] = '%' . $taxonomy . '%';
+            }
+
+            if ( is_object( $post ) && isset( $post->filter ) && 'sample' == $post->filter ) {
+                $sample = true;
+            }
+
+            $post_type = get_post_type_object( $post->post_type );
+            $permastruct = get_option( $post_type->name . '_permalink_structure' );
+
+            if ( empty( $permastruct ) && $post->post_type === 'post' ) {
+                $permastruct = get_option( 'permalink_structure' );
+            }
+
+            // prefer option over default
+            if ( !empty( $permastruct ) ) {
+                $permalink = $permastruct;
+            }
+            elseif ( isset( $post_type->rewrite[ 'permastruct' ] ) && !empty( $post_type->rewrite[ 'permastruct' ] ) ) {
+                $permalink = $post_type->rewrite[ 'permastruct' ];
+            }
+            else {
+                return $post_link;
+            }
+
+            $permalink = apply_filters( 'pre_post_link', $permalink, $post, $leavename );
+
+            if ( '' != $permalink && !in_array( $post->post_status, array( 'draft', 'pending', 'auto-draft' ) ) ) {
+                $unixtime = strtotime( $post->post_date );
+
+                // add ability to use any taxonomies in post type permastruct
+                $replace_terms = array();
+                foreach ( $taxonomies as $taxonomy ) {
+                    $term = '';
+                    $taxonomy_object = get_taxonomy( $taxonomy );
+                    if ( strpos( $permalink, '%' . $taxonomy . '%' ) !== false ) {
+                        $terms = get_the_terms( $post->ID, $taxonomy );
+						if ( $terms && ! is_wp_error( $terms ) ) {
+							if ( function_exists( 'wp_list_sort' ) ) {
+								$terms = wp_list_sort( $terms, 'term_id', 'ASC' );  // order by term_id ASC
+							} else {
+								usort( $terms, '_usort_terms_by_ID' ); // order by term_id ASC
+							}
+
+							/**
+							 * Filter the term that gets used in the `$tax` permalink token.
+							 *
+							 * @param WP_Term  $term  The `$tax` term to use in the permalink.
+							 * @param array    $terms Array of all `$tax` terms associated with the post.
+							 * @param WP_Post  $post  The post in question.
+							 */
+							$term_object = apply_filters( "post_link_{$taxonomy}", reset( $terms ), $terms, $post );
+
+							$term = $term_object->slug;
+							if ( $taxonomy_object->hierarchical && $parent = $term_object->parent ) {
+								$term = get_term_parents( $parent, $taxonomy, false, '/', true ) . $term;
+							}
 						}
-
-						/**
-						 * Filter the term that gets used in the `$tax` permalink token.
-						 *
-						 * @param WP_Term  $term  The `$tax` term to use in the permalink.
-						 * @param array    $terms Array of all `$tax` terms associated with the post.
-						 * @param WP_Post  $post  The post in question.
-						 */
-						$term_object = apply_filters( "post_link_{$taxonomy}", reset( $terms ), $terms, $post );
-
-						$term = $term_object->slug;
-						if ( $taxonomy_object->hierarchical && $parent = $term_object->parent ) {
-							$term = get_term_parents( $parent, $taxonomy, false, '/', true ) . $term;
+						// show default category in permalinks, without
+						// having to assign it explicitly
+						if ( empty( $term ) && $taxonomy == 'category' ) {
+							$default_category = get_category( get_option( 'default_category' ) );
+							$term = is_wp_error( $default_category ) ? '' : $default_category->slug;
 						}
-					}
-					// show default category in permalinks, without
-					// having to assign it explicitly
-					if ( empty( $term ) && $taxonomy == 'category' ) {
-						$default_category = get_category( get_option( 'default_category' ) );
-						$term = is_wp_error( $default_category ) ? '' : $default_category->slug;
-					}
+                    }
+                    $replace_terms[ $taxonomy ] = $term;
+                }
 
-				}
-				$replace_terms[ $taxonomy ] = $term;
-			}
+                $author = '';
+                if ( strpos( $permalink, '%author%' ) !== false ) {
+                    $authordata = get_userdata( $post->post_author );
+                    $author = $authordata->user_nicename;
+                }
 
-			$author = '';
-			if ( strpos( $permalink, '%author%' ) !== false ) {
-				$authordata = get_userdata( $post->post_author );
-				$author = $authordata->user_nicename;
-			}
+                $date = explode( " ", date( 'Y m d H i s', $unixtime ) );
+                $rewritereplace =
+                    array(
+                        $date[ 0 ],
+                        $date[ 1 ],
+                        $date[ 2 ],
+                        $date[ 3 ],
+                        $date[ 4 ],
+                        $date[ 5 ],
+                        $post->post_name,
+                        $post->ID,
+                        $author,
+                        $post->post_name,
+                    );
+                foreach ( $taxonomies as $taxonomy ) {
+                    $rewritereplace[] = $replace_terms[ $taxonomy ];
+                }
+                $permalink = home_url( str_replace( $rewritecode, $rewritereplace, $permalink ) );
+                $permalink = user_trailingslashit( $permalink, 'single' );
+            }
+            else { // if they're not using the fancy permalink option
+                $permalink = home_url( '?p=' . $post->ID );
+            }
 
-			$date = explode( " ", date( 'Y m d H i s', $unixtime ) );
-			$rewritereplace = array(
-				$date[0],
-				$date[1],
-				$date[2],
-				$date[3],
-				$date[4],
-				$date[5],
-				$post->post_name,
-				$post->ID,
-				$author,
-				$post->post_name,
-			);
-			foreach( $taxonomies as $taxonomy )
-				$rewritereplace[] = $replace_terms[ $taxonomy ];
-			$permalink = home_url( str_replace( $rewritecode, $rewritereplace, $permalink ) );
-			$permalink = user_trailingslashit( $permalink, 'single' );
-		} else { // if they're not using the fancy permalink option
-			$permalink = home_url( '?p=' . $post->ID );
-		}
+            return $permalink;
+        }
 
-		return $permalink;
-	}
-
-}
+    }
 
 }
 
 if ( ! function_exists( 'get_term_parents' ) ) {
 
-	/**
-	 * Retrieve term parents with separator.
-	 *
-	 * @param int $id Term ID.
-	 * @param string $taxonomy The taxonomy the term belongs to.
-	 * @param bool $link Optional, default is false. Whether to format with link.
-	 * @param string $separator Optional, default is '/'. How to separate categories.
-	 * @param bool $nicename Optional, default is false. Whether to use nice name for display.
-	 * @param array $visited Optional. Already linked to categories to prevent duplicates.
-	 * @return string
-	 */
-	function get_term_parents( $id, $taxonomy, $link = false, $separator = '/', $nicename = false, $visited = array() ) {
-		$chain = '';
-		$parent = get_term( $id, $taxonomy );
-		if ( is_wp_error( $parent ) )
-			return $parent;
+    /**
+     * Retrieve term parents with separator.
+     *
+     * @param int    $id Term ID.
+     * @param string $taxonomy The taxonomy the term belongs to.
+     * @param bool   $link Optional, default is false. Whether to format with link.
+     * @param string $separator Optional, default is '/'. How to separate categories.
+     * @param bool   $nicename Optional, default is false. Whether to use nice name for display.
+     * @param array  $visited Optional. Already linked to categories to prevent duplicates.
+     *
+     * @return string
+     */
+    function get_term_parents(
+        $id,
+        $taxonomy,
+        $link = false,
+        $separator = '/',
+        $nicename = false,
+        $visited = array()
+    ) {
+        $chain = '';
+        $parent = get_term( $id, $taxonomy );
+        if ( is_wp_error( $parent ) ) {
+            return $parent;
+        }
 
-		if ( $nicename )
-			$name = $parent->slug;
-		else
-			$name = $parent->cat_name;
+        if ( $nicename ) {
+            $name = $parent->slug;
+        }
+        else {
+            $name = $parent->cat_name;
+        }
 
-		if ( $parent->parent && ( $parent->parent != $parent->term_id ) && !in_array( $parent->parent, $visited ) ) {
-			$visited[] = $parent->parent;
-			$chain .= get_term_parents( $parent->parent, $taxonomy, $link, $separator, $nicename, $visited );
-		}
+        if ( $parent->parent && ( $parent->parent != $parent->term_id ) && ! in_array( $parent->parent, $visited ) ) {
+            $visited[] = $parent->parent;
+            $chain .= get_term_parents( $parent->parent, $taxonomy, $link, $separator, $nicename, $visited );
+        }
 
-		if ( $link )
-			$chain .= '<a href="' . get_term_link( $parent->term_id, $taxonomy ) . '" title="' . esc_attr( sprintf( __( "View all posts in %s" ), $parent->name ) ) . '">'.$name.'</a>' . $separator;
-		else
-			$chain .= $name.$separator;
-		return $chain;
-	}
+        if ( $link ) {
+            $chain .= '<a href="' . get_term_link( $parent->term_id, $taxonomy ) . '" title="' . esc_attr( sprintf( __( 'View all posts in %s' ), $parent->name ) ) . '">' . $name . '</a>' . $separator;
+        }
+        else {
+            $chain .= $name . $separator;
+        }
+
+        return $chain;
+    }
 
 }
 
@@ -409,45 +445,48 @@ if ( ! function_exists( 'get_term_parents' ) ) {
  */
 if ( ! function_exists( 'enable_permalinks_settings' ) ) {
 
-	// process the $_POST variable after all settings have been
-	// registered so they are whitelisted
-	add_action( 'admin_init', 'enable_permalinks_settings', 300 );
+    // process the $_POST variable after all settings have been
+    // registered so they are whitelisted
+    add_action( 'admin_init', 'enable_permalinks_settings', 300 );
 
-	function enable_permalinks_settings() {
-		global $new_whitelist_options;
+    function enable_permalinks_settings() {
+        global $new_whitelist_options;
 
-		// save hook for permalinks page
-		if ( isset( $_POST['permalink_structure'] ) || isset( $_POST['category_base'] ) ) {
-			check_admin_referer('update-permalink');
+        // save hook for permalinks page
+        if ( isset( $_POST['permalink_structure'] ) || isset( $_POST['category_base'] ) ) {
+            check_admin_referer( 'update-permalink' );
 
-			$option_page = 'permalink';
+            $option_page = 'permalink';
 
-			$capability = 'manage_options';
-			$capability = apply_filters( "option_page_capability_{$option_page}", $capability );
+            $capability = 'manage_options';
+            $capability = apply_filters( "option_page_capability_{$option_page}", $capability );
 
-			if ( !current_user_can( $capability ) )
-				wp_die(__('Cheatin&#8217; uh?'));
+            if ( ! current_user_can( $capability ) ) {
+                wp_die( __( 'Cheatin&#8217; uh?' ) );
+            }
 
-			// get extra permalink options
-			$options = $new_whitelist_options[ $option_page ];
+            // get extra permalink options
+            $options = $new_whitelist_options[ $option_page ];
 
-			if ( $options ) {
-				foreach ( $options as $option ) {
-					$option = trim($option);
-					$value = null;
-					if ( isset($_POST[$option]) )
-						$value = $_POST[$option];
-					if ( !is_array($value) )
-						$value = trim($value);
-					$value = stripslashes_deep($value);
-					update_option( $option, $value );
-				}
-			}
+            if ( $options ) {
+                foreach ( $options as $option ) {
+                    $option = trim( $option );
+                    $value = null;
+                    if ( isset( $_POST[ $option ] ) ) {
+                        $value = $_POST[ $option ];
+                    }
+                    if ( ! is_array( $value ) ) {
+                        $value = trim( $value );
+                    }
+                    $value = stripslashes_deep( $value );
+                    update_option( $option, $value );
+                }
+            }
 
-			/**
-			 *  Handle settings errors
-			 */
-			set_transient('settings_errors', get_settings_errors(), 30);
-		}
-	}
+            /**
+             *  Handle settings errors
+             */
+            set_transient( 'settings_errors', get_settings_errors(), 30 );
+        }
+    }
 }

--- a/wp-permastructure.php
+++ b/wp-permastructure.php
@@ -3,7 +3,7 @@
 Plugin Name: WP Permastructure
 Plugin URI: https://github.com/interconnectit/wp-permastructure
 Description: Adds the ability to define permalink structures for any custom post type using rewrite tags.
-Version: 1.6.0
+Version: 1.6.1
 Author: Robert O'Rourke
 Author URI: http://interconnectit.com
 License: GPLv2 or later
@@ -310,7 +310,10 @@ class wp_permastructure {
 
 		$permalink = apply_filters( 'pre_post_link', $permalink, $post, $leavename );
 
-		if ( '' !== $permalink && ! in_array( $post->post_status, array( 'draft', 'pending', 'auto-draft' ) ) ) {
+		if ( 
+			'' !== $permalink 
+			&& ! wp_force_plain_post_permalink( $post, $sample )
+		) {
 			$unixtime = strtotime( $post->post_date );
 
 			// add ability to use any taxonomies in post type permastruct
@@ -382,8 +385,9 @@ class wp_permastructure {
 			}
 			$permalink = home_url( str_replace( $rewritecode, $rewritereplace, $permalink ) );
 			$permalink = user_trailingslashit( $permalink, 'single' );
-		} else { // if they're not using the fancy permalink option
-			$permalink = home_url( '?p=' . $post->ID );
+		} else { 
+			// If they're not using the fancy permalink option or it's forced to be plain.
+			$permalink = $post_link;
 		}
 
 		return $permalink;

--- a/wp-permastructure.php
+++ b/wp-permastructure.php
@@ -316,8 +316,9 @@ class wp_permastructure {
 						$term_object = apply_filters( "post_link_{$taxonomy}", reset( $terms ), $terms, $post );
 
 						$term = $term_object->slug;
-						if ( $taxonomy_object->hierarchical && $parent = $term_object->parent )
-							$term = get_term_parents($parent, $taxonomy, false, '/', true) . $term;
+						if ( $taxonomy_object->hierarchical && $parent = $term_object->parent ) {
+							$term = get_term_parents( $parent, $taxonomy, false, '/', true ) . $term;
+						}
 					}
 					// show default category in permalinks, without
 					// having to assign it explicitly
@@ -331,14 +332,13 @@ class wp_permastructure {
 			}
 
 			$author = '';
-			if ( strpos($permalink, '%author%') !== false ) {
-				$authordata = get_userdata($post->post_author);
+			if ( strpos( $permalink, '%author%' ) !== false ) {
+				$authordata = get_userdata( $post->post_author );
 				$author = $authordata->user_nicename;
 			}
 
-			$date = explode(" ",date('Y m d H i s', $unixtime));
-			$rewritereplace =
-			array(
+			$date = explode( " ", date( 'Y m d H i s', $unixtime ) );
+			$rewritereplace = array(
 				$date[0],
 				$date[1],
 				$date[2],
@@ -352,10 +352,10 @@ class wp_permastructure {
 			);
 			foreach( $taxonomies as $taxonomy )
 				$rewritereplace[] = $replace_terms[ $taxonomy ];
-			$permalink = home_url( str_replace($rewritecode, $rewritereplace, $permalink) );
-			$permalink = user_trailingslashit($permalink, 'single');
+			$permalink = home_url( str_replace( $rewritecode, $rewritereplace, $permalink ) );
+			$permalink = user_trailingslashit( $permalink, 'single' );
 		} else { // if they're not using the fancy permalink option
-			$permalink = home_url('?p=' . $post->ID);
+			$permalink = home_url( '?p=' . $post->ID );
 		}
 
 		return $permalink;

--- a/wp-permastructure.php
+++ b/wp-permastructure.php
@@ -294,8 +294,18 @@ class wp_permastructure {
 					$terms = get_the_terms( $post->ID, $taxonomy );
 					if ( $terms ) {
 						usort($terms, '_usort_terms_by_ID'); // order by ID
-						$term = $terms[0]->slug;
-						if ( $taxonomy_object->hierarchical && $parent = $terms[0]->parent )
+
+						/**
+						 * Filter the term that gets used in the `$tax` permalink token.
+						 *
+						 * @param WP_Term  $term  The `$tax` term to use in the permalink.
+						 * @param array    $terms Array of all `$tax` terms associated with the post.
+						 * @param WP_Post  $post  The post in question.
+						 */
+						$term_object = apply_filters( "post_link_{$taxonomy}", reset( $terms ), $terms, $post );
+
+						$term = $term_object->slug;
+						if ( $taxonomy_object->hierarchical && $parent = $term_object->parent )
 							$term = get_term_parents($parent, $taxonomy, false, '/', true) . $term;
 					}
 					// show default category in permalinks, without

--- a/wp-permastructure.php
+++ b/wp-permastructure.php
@@ -19,9 +19,9 @@ License: GPLv2 or later
  * eg:
  *
  * register_post_type( 'my_type', array(
- *        ...
- *        'rewrite' => array( 'permastruct' => '/%custom_taxonomy%/%author%/%postname%/' ),
- *    ...
+ *   ...
+ *   'rewrite' => array( 'permastruct' => '/%custom_taxonomy%/%author%/%postname%/' ),
+ *   ...
  * ) );
  *
  * Alternatively you can set the permalink structure from the permalinks settings page
@@ -158,8 +158,7 @@ class wp_permastructure {
 			$filtered = wp_pre_kses_less_than( $filtered );
 			// This will strip extra whitespace for us.
 			$filtered = wp_strip_all_tags( $filtered, true );
-		}
-		else {
+		} else {
 			$filtered = trim( preg_replace( '/[\r\n\t ]+/', ' ', $filtered ) );
 		}
 
@@ -234,8 +233,7 @@ class wp_permastructure {
 					$rules[ $regex ] = $query . ( preg_match( '/(&|\?)(attachment|pagename)=/', $query ) ? '' : $post_type_query );
 					// Ensure permalinks that match a custom taxonomy path don't get swallowed.
 					$wp_rewrite->extra_rules_top[ $regex ] = $rules[ $regex ];
-				}
-				else {
+				} else {
 					unset( $rules[ $regex ] );
 				}
 			}
@@ -301,11 +299,9 @@ class wp_permastructure {
 		// prefer option over default
 		if ( !empty( $permastruct ) ) {
 			$permalink = $permastruct;
-		}
-		elseif ( isset( $post_type->rewrite[ 'permastruct' ] ) && ! empty( $post_type->rewrite[ 'permastruct' ] ) ) {
+		} elseif ( isset( $post_type->rewrite[ 'permastruct' ] ) && ! empty( $post_type->rewrite[ 'permastruct' ] ) ) {
 			$permalink = $post_type->rewrite[ 'permastruct' ];
-		}
-		else {
+		} else {
 			return $post_link;
 		}
 
@@ -377,8 +373,7 @@ class wp_permastructure {
 			}
 			$permalink = home_url( str_replace( $rewritecode, $rewritereplace, $permalink ) );
 			$permalink = user_trailingslashit( $permalink, 'single' );
-		}
-		else { // if they're not using the fancy permalink option
+		} else { // if they're not using the fancy permalink option
 			$permalink = home_url( '?p=' . $post->ID );
 		}
 
@@ -417,8 +412,7 @@ if ( ! function_exists( 'get_term_parents' ) ) {
 
 		if ( $nicename ) {
 			$name = $parent->slug;
-		}
-		else {
+		} else {
 			$name = $parent->cat_name;
 		}
 
@@ -429,8 +423,7 @@ if ( ! function_exists( 'get_term_parents' ) ) {
 
 		if ( $link ) {
 			$chain .= '<a href="' . get_term_link( $parent->term_id, $taxonomy ) . '" title="' . esc_attr( sprintf( __( 'View all posts in %s' ), $parent->name ) ) . '">' . $name . '</a>' . $separator;
-		}
-		else {
+		} else {
 			$chain .= $name . $separator;
 		}
 

--- a/wp-permastructure.php
+++ b/wp-permastructure.php
@@ -68,9 +68,9 @@ class wp_permastructure {
 	 * @return void
 	 */
 	public static function instance() {
-		null === self:: $instance AND self:: $instance = new self;
+		null === self::$instance AND self::$instance = new self;
 
-		return self:: $instance;
+		return self::$instance;
 	}
 
 
@@ -148,7 +148,7 @@ class wp_permastructure {
 	 * @return string    Sanitised permalink structure
 	 */
 	public function sanitize_permalink( $permalink ) {
-		if ( !empty( $permalink ) && !preg_match( '/%(post_id|postname)%/', $permalink ) ) {
+		if ( ! empty( $permalink ) && ! preg_match( '/%(post_id|postname)%/', $permalink ) ) {
 			add_settings_error( 'permalink_structure', 10, __( 'Permalink structures must contain at least the <code>%post_id%</code> or <code>%postname%</code>.' ) );
 		}
 
@@ -178,7 +178,7 @@ class wp_permastructure {
 		global $wp_rewrite;
 
 		// restore endpoints
-		if ( empty( $wp_rewrite->endpoints ) && !empty( $this->endpoints ) ) {
+		if ( empty( $wp_rewrite->endpoints ) && ! empty( $this->endpoints ) ) {
 			$wp_rewrite->endpoints = $this->endpoints;
 		}
 
@@ -192,15 +192,15 @@ class wp_permastructure {
 		foreach ( get_post_types( array( '_builtin' => false, 'public' => true ), 'objects' ) as $type ) {
 			// add/override the custom permalink structure if set in options
 			$post_type_permastruct = get_option( $type->name . '_permalink_structure' );
-			if ( $post_type_permastruct && !empty( $post_type_permastruct ) ) {
-				if ( !is_array( $type->rewrite ) ) {
+			if ( $post_type_permastruct && ! empty( $post_type_permastruct ) ) {
+				if ( ! is_array( $type->rewrite ) ) {
 					$type->rewrite = array();
 				}
 				$type->rewrite[ 'permastruct' ] = $post_type_permastruct;
 			}
 
 			// check we have a custom permalink structure
-			if ( !is_array( $type->rewrite ) || !isset( $type->rewrite[ 'permastruct' ] ) ) {
+			if ( ! is_array( $type->rewrite ) || ! isset( $type->rewrite[ 'permastruct' ] ) ) {
 				continue;
 			}
 
@@ -209,7 +209,7 @@ class wp_permastructure {
 				return array();
 			}, 11 );
 
-			if ( !isset( $permastructs[ $type->rewrite[ 'permastruct' ] ] ) ) {
+			if ( ! isset( $permastructs[ $type->rewrite[ 'permastruct' ] ] ) ) {
 				$permastructs[ $type->rewrite[ 'permastruct' ] ] = array();
 			}
 
@@ -259,12 +259,12 @@ class wp_permastructure {
 	 */
 	public function parse_permalinks( $post_link, $post, $leavename, $sample = false ) {
 		// Yoast Sitemap plug-in doesn't pass a WP_Post object causing a fatal, so we'll check for it and return.
-		if ( !is_a( $post, 'WP_Post' ) ) {
+		if ( ! is_a( $post, 'WP_Post' ) ) {
 			return $post_link;
 		}
 
 		// Make a stupid request and we'll do nothing.
-		if ( !post_type_exists( $post->post_type ) ) {
+		if ( ! post_type_exists( $post->post_type ) ) {
 			return $post_link;
 		}
 
@@ -302,7 +302,7 @@ class wp_permastructure {
 		if ( !empty( $permastruct ) ) {
 			$permalink = $permastruct;
 		}
-		elseif ( isset( $post_type->rewrite[ 'permastruct' ] ) && !empty( $post_type->rewrite[ 'permastruct' ] ) ) {
+		elseif ( isset( $post_type->rewrite[ 'permastruct' ] ) && ! empty( $post_type->rewrite[ 'permastruct' ] ) ) {
 			$permalink = $post_type->rewrite[ 'permastruct' ];
 		}
 		else {
@@ -344,7 +344,7 @@ class wp_permastructure {
 					}
 					// show default category in permalinks, without
 					// having to assign it explicitly
-					if ( empty( $term ) && $taxonomy == 'category' ) {
+					if ( empty( $term ) && $taxonomy === 'category' ) {
 						$default_category = get_category( get_option( 'default_category' ) );
 						$term = is_wp_error( $default_category ) ? '' : $default_category->slug;
 					}
@@ -387,57 +387,55 @@ class wp_permastructure {
 
 }
 
-}
-
 if ( ! function_exists( 'get_term_parents' ) ) {
 
-/**
- * Retrieve term parents with separator.
- *
- * @param int    $id Term ID.
- * @param string $taxonomy The taxonomy the term belongs to.
- * @param bool   $link Optional, default is false. Whether to format with link.
- * @param string $separator Optional, default is '/'. How to separate categories.
- * @param bool   $nicename Optional, default is false. Whether to use nice name for display.
- * @param array  $visited Optional. Already linked to categories to prevent duplicates.
- *
- * @return string
- */
-function get_term_parents(
-	$id,
-	$taxonomy,
-	$link = false,
-	$separator = '/',
-	$nicename = false,
-	$visited = array()
-) {
-	$chain = '';
-	$parent = get_term( $id, $taxonomy );
-	if ( is_wp_error( $parent ) ) {
-		return $parent;
-	}
+	/**
+	 * Retrieve term parents with separator.
+	 *
+	 * @param int    $id Term ID.
+	 * @param string $taxonomy The taxonomy the term belongs to.
+	 * @param bool   $link Optional, default is false. Whether to format with link.
+	 * @param string $separator Optional, default is '/'. How to separate categories.
+	 * @param bool   $nicename Optional, default is false. Whether to use nice name for display.
+	 * @param array  $visited Optional. Already linked to categories to prevent duplicates.
+	 *
+	 * @return string
+	 */
+	function get_term_parents(
+		$id,
+		$taxonomy,
+		$link = false,
+		$separator = '/',
+		$nicename = false,
+		$visited = array()
+	) {
+		$chain = '';
+		$parent = get_term( $id, $taxonomy );
+		if ( is_wp_error( $parent ) ) {
+			return $parent;
+		}
 
-	if ( $nicename ) {
-		$name = $parent->slug;
-	}
-	else {
-		$name = $parent->cat_name;
-	}
+		if ( $nicename ) {
+			$name = $parent->slug;
+		}
+		else {
+			$name = $parent->cat_name;
+		}
 
-	if ( $parent->parent && ( $parent->parent != $parent->term_id ) && ! in_array( $parent->parent, $visited ) ) {
-		$visited[] = $parent->parent;
-		$chain .= get_term_parents( $parent->parent, $taxonomy, $link, $separator, $nicename, $visited );
-	}
+		if ( $parent->parent && ( $parent->parent != $parent->term_id ) && ! in_array( $parent->parent, $visited ) ) {
+			$visited[] = $parent->parent;
+			$chain .= get_term_parents( $parent->parent, $taxonomy, $link, $separator, $nicename, $visited );
+		}
 
-	if ( $link ) {
-		$chain .= '<a href="' . get_term_link( $parent->term_id, $taxonomy ) . '" title="' . esc_attr( sprintf( __( 'View all posts in %s' ), $parent->name ) ) . '">' . $name . '</a>' . $separator;
-	}
-	else {
-		$chain .= $name . $separator;
-	}
+		if ( $link ) {
+			$chain .= '<a href="' . get_term_link( $parent->term_id, $taxonomy ) . '" title="' . esc_attr( sprintf( __( 'View all posts in %s' ), $parent->name ) ) . '">' . $name . '</a>' . $separator;
+		}
+		else {
+			$chain .= $name . $separator;
+		}
 
-	return $chain;
-}
+		return $chain;
+	}
 
 }
 
@@ -447,47 +445,49 @@ function get_term_parents(
  */
 if ( ! function_exists( 'enable_permalinks_settings' ) ) {
 
-// process the $_POST variable after all settings have been
-// registered so they are whitelisted
-add_action( 'admin_init', 'enable_permalinks_settings', 300 );
+	// process the $_POST variable after all settings have been
+	// registered so they are whitelisted
+	add_action( 'admin_init', 'enable_permalinks_settings', 300 );
 
-function enable_permalinks_settings() {
-	global $new_whitelist_options;
+	function enable_permalinks_settings() {
+		global $new_whitelist_options;
 
-	// save hook for permalinks page
-	if ( isset( $_POST['permalink_structure'] ) || isset( $_POST['category_base'] ) ) {
-		check_admin_referer( 'update-permalink' );
+		// save hook for permalinks page
+		if ( isset( $_POST['permalink_structure'] ) || isset( $_POST['category_base'] ) ) {
+			check_admin_referer( 'update-permalink' );
 
-		$option_page = 'permalink';
+			$option_page = 'permalink';
 
-		$capability = 'manage_options';
-		$capability = apply_filters( "option_page_capability_{$option_page}", $capability );
+			$capability = 'manage_options';
+			$capability = apply_filters( "option_page_capability_{$option_page}", $capability );
 
-		if ( ! current_user_can( $capability ) ) {
-			wp_die( __( 'Cheatin&#8217; uh?' ) );
-		}
-
-		// get extra permalink options
-		$options = $new_whitelist_options[ $option_page ];
-
-		if ( $options ) {
-			foreach ( $options as $option ) {
-				$option = trim( $option );
-				$value = null;
-				if ( isset( $_POST[ $option ] ) ) {
-					$value = $_POST[ $option ];
-				}
-				if ( ! is_array( $value ) ) {
-					$value = trim( $value );
-				}
-				$value = stripslashes_deep( $value );
-				update_option( $option, $value );
+			if ( ! current_user_can( $capability ) ) {
+				wp_die( __( 'Cheatin&#8217; uh?' ) );
 			}
-		}
 
-		/**
-		 *  Handle settings errors
-		 */
-		set_transient( 'settings_errors', get_settings_errors(), 30 );
+			// get extra permalink options
+			$options = $new_whitelist_options[ $option_page ];
+
+			if ( $options ) {
+				foreach ( $options as $option ) {
+					$option = trim( $option );
+					$value = null;
+					if ( isset( $_POST[ $option ] ) ) {
+						$value = $_POST[ $option ];
+					}
+					if ( ! is_array( $value ) ) {
+						$value = trim( $value );
+					}
+					$value = stripslashes_deep( $value );
+					update_option( $option, $value );
+				}
+			}
+
+			/**
+			 *  Handle settings errors
+			 */
+			set_transient( 'settings_errors', get_settings_errors(), 30 );
+		}
 	}
+
 }

--- a/wp-permastructure.php
+++ b/wp-permastructure.php
@@ -3,7 +3,7 @@
 Plugin Name: WP Permastructure
 Plugin URI: https://github.com/interconnectit/wp-permastructure
 Description: Adds the ability to define permalink structures for any custom post type using rewrite tags.
-Version: 1.4.4
+Version: 1.5.0
 Author: Robert O'Rourke
 Author URI: http://interconnectit.com
 License: GPLv2 or later
@@ -297,7 +297,7 @@ class wp_permastructure {
 		}
 
 		// prefer option over default
-		if ( !empty( $permastruct ) ) {
+		if ( ! empty( $permastruct ) ) {
 			$permalink = $permastruct;
 		} elseif ( isset( $post_type->rewrite[ 'permastruct' ] ) && ! empty( $post_type->rewrite[ 'permastruct' ] ) ) {
 			$permalink = $post_type->rewrite[ 'permastruct' ];
@@ -307,7 +307,7 @@ class wp_permastructure {
 
 		$permalink = apply_filters( 'pre_post_link', $permalink, $post, $leavename );
 
-		if ( '' != $permalink && !in_array( $post->post_status, array( 'draft', 'pending', 'auto-draft' ) ) ) {
+		if ( '' !== $permalink && ! in_array( $post->post_status, array( 'draft', 'pending', 'auto-draft' ) ) ) {
 			$unixtime = strtotime( $post->post_date );
 
 			// add ability to use any taxonomies in post type permastruct

--- a/wp-permastructure.php
+++ b/wp-permastructure.php
@@ -234,16 +234,19 @@ class wp_permastructure {
 	 * Generic version of standard permalink parsing function. Adds support for
 	 * custom taxonomies as well as the standard %author% etc...
 	 *
-	 * @param string $post_link The post URL
-	 * @param WP_Post $post      The post object
-	 * @param bool $leavename Passed to pre_post_link filter
-	 * @param bool $sample    Used in admin if generating an example permalink
+	 * @param string $post_link             The post URL
+	 * @param WP_Post|object|int|null $post The post object
+	 * @param bool $leavename               Passed to pre_post_link filter
+	 * @param bool $sample                  Used in admin if generating an example permalink
 	 *
-	 * @return string    The parsed permalink
+	 * @return string The parsed permalink
 	 */
 	public function parse_permalinks( $post_link, $post, $leavename, $sample = false ) {
-		// Yoast Sitemap plug-in doesn't pass a WP_Post object causing a fatal, so we'll check for it and return.
-		if ( !is_a( $post, 'WP_Post' ) ) {
+		// Ensure WP_Post object. Some plugins pass arbitrary objects or other data.
+		$post = get_post( $post );
+
+		// Only bail if the above get_post() didn't work.
+		if ( ! $post instanceof WP_Post ) {
 			return $post_link;
 		}
 

--- a/wp-permastructure.php
+++ b/wp-permastructure.php
@@ -297,11 +297,11 @@ class wp_permastructure {
 				if ( strpos($permalink, '%'. $taxonomy .'%') !== false ) {
 					$terms = get_the_terms( $post->ID, $taxonomy );
 					if ( $terms ) {
-                        if( function_exists( 'wp_list_sort' ) ) {
-                            $terms = wp_list_sort( $terms, 'term_id', 'ASC' );  // order by term_id ASC
-                        } else {
-                            usort( $terms, '_usort_terms_by_ID' ); // order by term_id ASC
-                        }
+						if( function_exists( 'wp_list_sort' ) ) {
+						    $terms = wp_list_sort( $terms, 'term_id', 'ASC' );  // order by term_id ASC
+						} else {
+						    usort( $terms, '_usort_terms_by_ID' ); // order by term_id ASC
+						}
 
 						/**
 						 * Filter the term that gets used in the `$tax` permalink token.

--- a/wp-permastructure.php
+++ b/wp-permastructure.php
@@ -242,10 +242,10 @@ class wp_permastructure {
 	 * @return string    The parsed permalink
 	 */
 	public function parse_permalinks( $post_link, $post, $leavename, $sample = false ) {
-	    // Yoast Sitemap plug-in doesn't pass a WP_Post object causing a fatal, so we'll check for it and return.
-	    if ( !is_a( $post, 'WP_Post' ) ) {
-            return $post_link;
-        }
+		// Yoast Sitemap plug-in doesn't pass a WP_Post object causing a fatal, so we'll check for it and return.
+		if ( !is_a( $post, 'WP_Post' ) ) {
+			return $post_link;
+		}
 
 		// Make a stupid request and we'll do nothing.
 		if ( !post_type_exists( $post->post_type ) )

--- a/wp-permastructure.php
+++ b/wp-permastructure.php
@@ -40,285 +40,285 @@ License: GPLv2 or later
 
 if ( !class_exists( 'wp_permastructure' ) ) {
 
-    add_action( 'init', array( 'wp_permastructure', 'instance' ), 0 );
+	add_action( 'init', array( 'wp_permastructure', 'instance' ), 0 );
 
-    class wp_permastructure {
+	class wp_permastructure {
 
-        public $settings_section = 'wp_permastructure';
+		public $settings_section = 'wp_permastructure';
 
-        /**
-         * @var protect endpoints from being vaped if a category/tag slug is set
-         */
-        protected $endpoints;
+		/**
+		 * @var protect endpoints from being vaped if a category/tag slug is set
+		 */
+		protected $endpoints;
 
-        /**
-         * Reusable object instance.
-         *
-         * @type object
-         */
-        protected static $instance = null;
+		/**
+		 * Reusable object instance.
+		 *
+		 * @type object
+		 */
+		protected static $instance = null;
 
-        /**
-         * Creates a new instance. Called on 'init'.
-         * May be used to access class methods from outside.
-         *
-         * @see    __construct()
-         * @return void
-         */
-        public static function instance() {
-            null === self:: $instance AND self:: $instance = new self;
+		/**
+		 * Creates a new instance. Called on 'init'.
+		 * May be used to access class methods from outside.
+		 *
+		 * @see    __construct()
+		 * @return void
+		 */
+		public static function instance() {
+			null === self:: $instance AND self:: $instance = new self;
 
-            return self:: $instance;
-        }
-
-
-        public function __construct() {
-
-            // Late init to protect endpoints
-            add_action( 'init', array( $this, 'late_init' ), 999 );
-
-            // Settings fields on permalinks page
-            add_action( 'admin_init', array( $this, 'admin_init' ) );
-
-            // add our new peramstructs to the rewrite rules
-            add_filter( 'post_rewrite_rules', array( $this, 'add_permastructs' ) );
-
-            // parse the generated links - enable custom taxonomies for built in post links
-            add_filter( 'post_link', array( $this, 'parse_permalinks' ), 10, 3 );
-            add_filter( 'post_type_link', array( $this, 'parse_permalinks' ), 10, 4 );
-
-            // that's it!
-
-        }
+			return self:: $instance;
+		}
 
 
-        public function late_init() {
-            global $wp_rewrite;
-            $this->endpoints = $wp_rewrite->endpoints;
-        }
+		public function __construct() {
+
+			// Late init to protect endpoints
+			add_action( 'init', array( $this, 'late_init' ), 999 );
+
+			// Settings fields on permalinks page
+			add_action( 'admin_init', array( $this, 'admin_init' ) );
+
+			// add our new peramstructs to the rewrite rules
+			add_filter( 'post_rewrite_rules', array( $this, 'add_permastructs' ) );
+
+			// parse the generated links - enable custom taxonomies for built in post links
+			add_filter( 'post_link', array( $this, 'parse_permalinks' ), 10, 3 );
+			add_filter( 'post_type_link', array( $this, 'parse_permalinks' ), 10, 4 );
+
+			// that's it!
+
+		}
 
 
-        /**
-         * Add the settings UI
-         */
-        public function admin_init() {
-
-            add_settings_section(
-                $this->settings_section,
-                __( 'Custom post type permalink settings' ),
-                array( $this, 'settings_section' ),
-                'permalink'
-            );
-
-            foreach ( get_post_types( array( '_builtin' => false, 'public' => true ), 'objects' ) as $type ) {
-                $id = $type->name . '_permalink_structure';
-
-                register_setting( 'permalink', $id, array( $this, 'sanitize_permalink' ) );
-                add_settings_field(
-                    $id,
-                    __( $type->label . ' permalink structure' ),
-                    array( $this, 'permalink_field' ),
-                    'permalink',
-                    $this->settings_section,
-                    array( 'id' => $id )
-                );
-            }
-
-        }
+		public function late_init() {
+			global $wp_rewrite;
+			$this->endpoints = $wp_rewrite->endpoints;
+		}
 
 
-        public function settings_section() {
+		/**
+		 * Add the settings UI
+		 */
+		public function admin_init() {
 
-        }
+			add_settings_section(
+				$this->settings_section,
+				__( 'Custom post type permalink settings' ),
+				array( $this, 'settings_section' ),
+				'permalink'
+			);
 
+			foreach ( get_post_types( array( '_builtin' => false, 'public' => true ), 'objects' ) as $type ) {
+				$id = $type->name . '_permalink_structure';
 
-        public function permalink_field( $args ) {
-            echo '<input type="text" class="regular-text code" value="' . esc_attr( get_option( $args[ 'id' ] ) ) . '" id="' . $args[ 'id' ] . '" name="' . $args[ 'id' ] . '" />';
-        }
+				register_setting( 'permalink', $id, array( $this, 'sanitize_permalink' ) );
+				add_settings_field(
+					$id,
+					__( $type->label . ' permalink structure' ),
+					array( $this, 'permalink_field' ),
+					'permalink',
+					$this->settings_section,
+					array( 'id' => $id )
+				);
+			}
 
-
-        /**
-         * Runs a simple sanitisation of the custom post type permalink structures
-         * and adds an error if no post ID or post name present
-         *
-         * @param string $permalink The permalink structure
-         *
-         * @return string    Sanitised permalink structure
-         */
-        public function sanitize_permalink( $permalink ) {
-            if ( !empty( $permalink ) && !preg_match( '/%(post_id|postname)%/', $permalink ) ) {
-                add_settings_error( 'permalink_structure', 10, __( 'Permalink structures must contain at least the <code>%post_id%</code> or <code>%postname%</code>.' ) );
-            }
-
-            $filtered = wp_check_invalid_utf8( $permalink );
-
-            if ( strpos( $filtered, '<' ) !== false ) {
-                $filtered = wp_pre_kses_less_than( $filtered );
-                // This will strip extra whitespace for us.
-                $filtered = wp_strip_all_tags( $filtered, true );
-            }
-            else {
-                $filtered = trim( preg_replace( '/[\r\n\t ]+/', ' ', $filtered ) );
-            }
-
-            return preg_replace( '/[^a-zA-Z0-9\/\%\._-]*/', '', $filtered );
-        }
+		}
 
 
-        /**
-         * This function removes unnecessary rules and adds in the new rules
-         *
-         * @param array $rules The rewrite rules array for post permalinks
-         *
-         * @return array    The modified rules array
-         */
-        public function add_permastructs( $rules ) {
-            global $wp_rewrite;
+		public function settings_section() {
 
-            // restore endpoints
-            if ( empty( $wp_rewrite->endpoints ) && !empty( $this->endpoints ) ) {
-                $wp_rewrite->endpoints = $this->endpoints;
-            }
-
-            $permastruct = $wp_rewrite->permalink_structure;
-            $permastructs = array( $permastruct => array( 'post' ) );
-
-            // force page rewrite to bottom
-            $wp_rewrite->use_verbose_page_rules = false;
-
-            // get permastructs foreach custom post type and group any that use the same struct
-            foreach ( get_post_types( array( '_builtin' => false, 'public' => true ), 'objects' ) as $type ) {
-                // add/override the custom permalink structure if set in options
-                $post_type_permastruct = get_option( $type->name . '_permalink_structure' );
-                if ( $post_type_permastruct && !empty( $post_type_permastruct ) ) {
-                    if ( !is_array( $type->rewrite ) ) {
-                        $type->rewrite = array();
-                    }
-                    $type->rewrite[ 'permastruct' ] = $post_type_permastruct;
-                }
-
-                // check we have a custom permalink structure
-                if ( !is_array( $type->rewrite ) || !isset( $type->rewrite[ 'permastruct' ] ) ) {
-                    continue;
-                }
-
-                // remove default struct rules
-                add_filter( $type->name . '_rewrite_rules', function( $rules ) {
-                    return array();
-                }, 11 );
-
-                if ( !isset( $permastructs[ $type->rewrite[ 'permastruct' ] ] ) ) {
-                    $permastructs[ $type->rewrite[ 'permastruct' ] ] = array();
-                }
-
-                $permastructs[ $type->rewrite[ 'permastruct' ] ][] = $type->name;
-            }
-
-            $rules = array();
-
-            // add our permastructs scoped to the post types - overwriting any keys that already exist
-            foreach ( $permastructs as $struct => $post_types ) {
-
-                // if a struct is %postname% only then we need page rules first - if not found wp tries again with later rules
-                if ( preg_match( '/^\/?%postname%\/?$/', $struct ) ) {
-                    $wp_rewrite->use_verbose_page_rules = true;
-                }
-
-                // get rewrite rules without walking dirs
-                $post_type_rules_temp = $wp_rewrite->generate_rewrite_rules( $struct, EP_PERMALINK, false, true, false, false, true );
-                foreach ( $post_type_rules_temp as $regex => $query ) {
-                    if ( preg_match( '/(&|\?)(cpage|attachment|p|name|pagename)=/', $query ) ) {
-                        $post_type_query = ( count( $post_types ) < 2 ? '&post_type=' . $post_types[ 0 ] : '&post_type[]=' . join( '&post_type[]=', array_unique( $post_types ) ) );
-                        $rules[ $regex ] = $query . ( preg_match( '/(&|\?)(attachment|pagename)=/', $query ) ? '' : $post_type_query );
-                        // Ensure permalinks that match a custom taxonomy path don't get swallowed.
-                        $wp_rewrite->extra_rules_top[ $regex ] = $rules[ $regex ];
-                    }
-                    else {
-                        unset( $rules[ $regex ] );
-                    }
-                }
-
-            }
-
-            return $rules;
-        }
+		}
 
 
-        /**
-         * Generic version of standard permalink parsing function. Adds support for
-         * custom taxonomies as well as the standard %author% etc...
-         *
-         * @param string  $post_link The post URL
-         * @param WP_Post $post The post object
-         * @param bool    $leavename Passed to pre_post_link filter
-         * @param bool    $sample Used in admin if generating an example permalink
-         *
-         * @return string    The parsed permalink
-         */
-        public function parse_permalinks( $post_link, $post, $leavename, $sample = false ) {
-            // Yoast Sitemap plug-in doesn't pass a WP_Post object causing a fatal, so we'll check for it and return.
-            if ( !is_a( $post, 'WP_Post' ) ) {
-                return $post_link;
-            }
+		public function permalink_field( $args ) {
+			echo '<input type="text" class="regular-text code" value="' . esc_attr( get_option( $args[ 'id' ] ) ) . '" id="' . $args[ 'id' ] . '" name="' . $args[ 'id' ] . '" />';
+		}
 
-            // Make a stupid request and we'll do nothing.
-            if ( !post_type_exists( $post->post_type ) ) {
-                return $post_link;
-            }
 
-            $rewritecode = array(
-                '%year%',
-                '%monthnum%',
-                '%day%',
-                '%hour%',
-                '%minute%',
-                '%second%',
-                $leavename ? '' : '%postname%',
-                '%post_id%',
-                '%author%',
-                $leavename ? '' : '%pagename%',
-            );
+		/**
+		 * Runs a simple sanitisation of the custom post type permalink structures
+		 * and adds an error if no post ID or post name present
+		 *
+		 * @param string $permalink The permalink structure
+		 *
+		 * @return string    Sanitised permalink structure
+		 */
+		public function sanitize_permalink( $permalink ) {
+			if ( !empty( $permalink ) && !preg_match( '/%(post_id|postname)%/', $permalink ) ) {
+				add_settings_error( 'permalink_structure', 10, __( 'Permalink structures must contain at least the <code>%post_id%</code> or <code>%postname%</code>.' ) );
+			}
 
-            $taxonomies = get_object_taxonomies( $post->post_type );
+			$filtered = wp_check_invalid_utf8( $permalink );
 
-            foreach ( $taxonomies as $taxonomy ) {
-                $rewritecode[] = '%' . $taxonomy . '%';
-            }
+			if ( strpos( $filtered, '<' ) !== false ) {
+				$filtered = wp_pre_kses_less_than( $filtered );
+				// This will strip extra whitespace for us.
+				$filtered = wp_strip_all_tags( $filtered, true );
+			}
+			else {
+				$filtered = trim( preg_replace( '/[\r\n\t ]+/', ' ', $filtered ) );
+			}
 
-            if ( is_object( $post ) && isset( $post->filter ) && 'sample' == $post->filter ) {
-                $sample = true;
-            }
+			return preg_replace( '/[^a-zA-Z0-9\/\%\._-]*/', '', $filtered );
+		}
 
-            $post_type = get_post_type_object( $post->post_type );
-            $permastruct = get_option( $post_type->name . '_permalink_structure' );
 
-            if ( empty( $permastruct ) && $post->post_type === 'post' ) {
-                $permastruct = get_option( 'permalink_structure' );
-            }
+		/**
+		 * This function removes unnecessary rules and adds in the new rules
+		 *
+		 * @param array $rules The rewrite rules array for post permalinks
+		 *
+		 * @return array    The modified rules array
+		 */
+		public function add_permastructs( $rules ) {
+			global $wp_rewrite;
 
-            // prefer option over default
-            if ( !empty( $permastruct ) ) {
-                $permalink = $permastruct;
-            }
-            elseif ( isset( $post_type->rewrite[ 'permastruct' ] ) && !empty( $post_type->rewrite[ 'permastruct' ] ) ) {
-                $permalink = $post_type->rewrite[ 'permastruct' ];
-            }
-            else {
-                return $post_link;
-            }
+			// restore endpoints
+			if ( empty( $wp_rewrite->endpoints ) && !empty( $this->endpoints ) ) {
+				$wp_rewrite->endpoints = $this->endpoints;
+			}
 
-            $permalink = apply_filters( 'pre_post_link', $permalink, $post, $leavename );
+			$permastruct = $wp_rewrite->permalink_structure;
+			$permastructs = array( $permastruct => array( 'post' ) );
 
-            if ( '' != $permalink && !in_array( $post->post_status, array( 'draft', 'pending', 'auto-draft' ) ) ) {
-                $unixtime = strtotime( $post->post_date );
+			// force page rewrite to bottom
+			$wp_rewrite->use_verbose_page_rules = false;
 
-                // add ability to use any taxonomies in post type permastruct
-                $replace_terms = array();
-                foreach ( $taxonomies as $taxonomy ) {
-                    $term = '';
-                    $taxonomy_object = get_taxonomy( $taxonomy );
-                    if ( strpos( $permalink, '%' . $taxonomy . '%' ) !== false ) {
-                        $terms = get_the_terms( $post->ID, $taxonomy );
+			// get permastructs foreach custom post type and group any that use the same struct
+			foreach ( get_post_types( array( '_builtin' => false, 'public' => true ), 'objects' ) as $type ) {
+				// add/override the custom permalink structure if set in options
+				$post_type_permastruct = get_option( $type->name . '_permalink_structure' );
+				if ( $post_type_permastruct && !empty( $post_type_permastruct ) ) {
+					if ( !is_array( $type->rewrite ) ) {
+						$type->rewrite = array();
+					}
+					$type->rewrite[ 'permastruct' ] = $post_type_permastruct;
+				}
+
+				// check we have a custom permalink structure
+				if ( !is_array( $type->rewrite ) || !isset( $type->rewrite[ 'permastruct' ] ) ) {
+					continue;
+				}
+
+				// remove default struct rules
+				add_filter( $type->name . '_rewrite_rules', function( $rules ) {
+					return array();
+				}, 11 );
+
+				if ( !isset( $permastructs[ $type->rewrite[ 'permastruct' ] ] ) ) {
+					$permastructs[ $type->rewrite[ 'permastruct' ] ] = array();
+				}
+
+				$permastructs[ $type->rewrite[ 'permastruct' ] ][] = $type->name;
+			}
+
+			$rules = array();
+
+			// add our permastructs scoped to the post types - overwriting any keys that already exist
+			foreach ( $permastructs as $struct => $post_types ) {
+
+				// if a struct is %postname% only then we need page rules first - if not found wp tries again with later rules
+				if ( preg_match( '/^\/?%postname%\/?$/', $struct ) ) {
+					$wp_rewrite->use_verbose_page_rules = true;
+				}
+
+				// get rewrite rules without walking dirs
+				$post_type_rules_temp = $wp_rewrite->generate_rewrite_rules( $struct, EP_PERMALINK, false, true, false, false, true );
+				foreach ( $post_type_rules_temp as $regex => $query ) {
+					if ( preg_match( '/(&|\?)(cpage|attachment|p|name|pagename)=/', $query ) ) {
+						$post_type_query = ( count( $post_types ) < 2 ? '&post_type=' . $post_types[ 0 ] : '&post_type[]=' . join( '&post_type[]=', array_unique( $post_types ) ) );
+						$rules[ $regex ] = $query . ( preg_match( '/(&|\?)(attachment|pagename)=/', $query ) ? '' : $post_type_query );
+						// Ensure permalinks that match a custom taxonomy path don't get swallowed.
+						$wp_rewrite->extra_rules_top[ $regex ] = $rules[ $regex ];
+					}
+					else {
+						unset( $rules[ $regex ] );
+					}
+				}
+
+			}
+
+			return $rules;
+		}
+
+
+		/**
+		 * Generic version of standard permalink parsing function. Adds support for
+		 * custom taxonomies as well as the standard %author% etc...
+		 *
+		 * @param string  $post_link The post URL
+		 * @param WP_Post $post The post object
+		 * @param bool    $leavename Passed to pre_post_link filter
+		 * @param bool    $sample Used in admin if generating an example permalink
+		 *
+		 * @return string    The parsed permalink
+		 */
+		public function parse_permalinks( $post_link, $post, $leavename, $sample = false ) {
+			// Yoast Sitemap plug-in doesn't pass a WP_Post object causing a fatal, so we'll check for it and return.
+			if ( !is_a( $post, 'WP_Post' ) ) {
+				return $post_link;
+			}
+
+			// Make a stupid request and we'll do nothing.
+			if ( !post_type_exists( $post->post_type ) ) {
+				return $post_link;
+			}
+
+			$rewritecode = array(
+				'%year%',
+				'%monthnum%',
+				'%day%',
+				'%hour%',
+				'%minute%',
+				'%second%',
+				$leavename ? '' : '%postname%',
+				'%post_id%',
+				'%author%',
+				$leavename ? '' : '%pagename%',
+			);
+
+			$taxonomies = get_object_taxonomies( $post->post_type );
+
+			foreach ( $taxonomies as $taxonomy ) {
+				$rewritecode[] = '%' . $taxonomy . '%';
+			}
+
+			if ( is_object( $post ) && isset( $post->filter ) && 'sample' == $post->filter ) {
+				$sample = true;
+			}
+
+			$post_type = get_post_type_object( $post->post_type );
+			$permastruct = get_option( $post_type->name . '_permalink_structure' );
+
+			if ( empty( $permastruct ) && $post->post_type === 'post' ) {
+				$permastruct = get_option( 'permalink_structure' );
+			}
+
+			// prefer option over default
+			if ( !empty( $permastruct ) ) {
+				$permalink = $permastruct;
+			}
+			elseif ( isset( $post_type->rewrite[ 'permastruct' ] ) && !empty( $post_type->rewrite[ 'permastruct' ] ) ) {
+				$permalink = $post_type->rewrite[ 'permastruct' ];
+			}
+			else {
+				return $post_link;
+			}
+
+			$permalink = apply_filters( 'pre_post_link', $permalink, $post, $leavename );
+
+			if ( '' != $permalink && !in_array( $post->post_status, array( 'draft', 'pending', 'auto-draft' ) ) ) {
+				$unixtime = strtotime( $post->post_date );
+
+				// add ability to use any taxonomies in post type permastruct
+				$replace_terms = array();
+				foreach ( $taxonomies as $taxonomy ) {
+					$term = '';
+					$taxonomy_object = get_taxonomy( $taxonomy );
+					if ( strpos( $permalink, '%' . $taxonomy . '%' ) !== false ) {
+						$terms = get_the_terms( $post->ID, $taxonomy );
 						if ( $terms && ! is_wp_error( $terms ) ) {
 							if ( function_exists( 'wp_list_sort' ) ) {
 								$terms = wp_list_sort( $terms, 'term_id', 'ASC' );  // order by term_id ASC
@@ -346,96 +346,96 @@ if ( !class_exists( 'wp_permastructure' ) ) {
 							$default_category = get_category( get_option( 'default_category' ) );
 							$term = is_wp_error( $default_category ) ? '' : $default_category->slug;
 						}
-                    }
-                    $replace_terms[ $taxonomy ] = $term;
-                }
+					}
+					$replace_terms[ $taxonomy ] = $term;
+				}
 
-                $author = '';
-                if ( strpos( $permalink, '%author%' ) !== false ) {
-                    $authordata = get_userdata( $post->post_author );
-                    $author = $authordata->user_nicename;
-                }
+				$author = '';
+				if ( strpos( $permalink, '%author%' ) !== false ) {
+					$authordata = get_userdata( $post->post_author );
+					$author = $authordata->user_nicename;
+				}
 
-                $date = explode( " ", date( 'Y m d H i s', $unixtime ) );
-                $rewritereplace =
-                    array(
-                        $date[ 0 ],
-                        $date[ 1 ],
-                        $date[ 2 ],
-                        $date[ 3 ],
-                        $date[ 4 ],
-                        $date[ 5 ],
-                        $post->post_name,
-                        $post->ID,
-                        $author,
-                        $post->post_name,
-                    );
-                foreach ( $taxonomies as $taxonomy ) {
-                    $rewritereplace[] = $replace_terms[ $taxonomy ];
-                }
-                $permalink = home_url( str_replace( $rewritecode, $rewritereplace, $permalink ) );
-                $permalink = user_trailingslashit( $permalink, 'single' );
-            }
-            else { // if they're not using the fancy permalink option
-                $permalink = home_url( '?p=' . $post->ID );
-            }
+				$date = explode( " ", date( 'Y m d H i s', $unixtime ) );
+				$rewritereplace =
+					array(
+						$date[ 0 ],
+						$date[ 1 ],
+						$date[ 2 ],
+						$date[ 3 ],
+						$date[ 4 ],
+						$date[ 5 ],
+						$post->post_name,
+						$post->ID,
+						$author,
+						$post->post_name,
+					);
+				foreach ( $taxonomies as $taxonomy ) {
+					$rewritereplace[] = $replace_terms[ $taxonomy ];
+				}
+				$permalink = home_url( str_replace( $rewritecode, $rewritereplace, $permalink ) );
+				$permalink = user_trailingslashit( $permalink, 'single' );
+			}
+			else { // if they're not using the fancy permalink option
+				$permalink = home_url( '?p=' . $post->ID );
+			}
 
-            return $permalink;
-        }
+			return $permalink;
+		}
 
-    }
+	}
 
 }
 
 if ( ! function_exists( 'get_term_parents' ) ) {
 
-    /**
-     * Retrieve term parents with separator.
-     *
-     * @param int    $id Term ID.
-     * @param string $taxonomy The taxonomy the term belongs to.
-     * @param bool   $link Optional, default is false. Whether to format with link.
-     * @param string $separator Optional, default is '/'. How to separate categories.
-     * @param bool   $nicename Optional, default is false. Whether to use nice name for display.
-     * @param array  $visited Optional. Already linked to categories to prevent duplicates.
-     *
-     * @return string
-     */
-    function get_term_parents(
-        $id,
-        $taxonomy,
-        $link = false,
-        $separator = '/',
-        $nicename = false,
-        $visited = array()
-    ) {
-        $chain = '';
-        $parent = get_term( $id, $taxonomy );
-        if ( is_wp_error( $parent ) ) {
-            return $parent;
-        }
+	/**
+	 * Retrieve term parents with separator.
+	 *
+	 * @param int    $id Term ID.
+	 * @param string $taxonomy The taxonomy the term belongs to.
+	 * @param bool   $link Optional, default is false. Whether to format with link.
+	 * @param string $separator Optional, default is '/'. How to separate categories.
+	 * @param bool   $nicename Optional, default is false. Whether to use nice name for display.
+	 * @param array  $visited Optional. Already linked to categories to prevent duplicates.
+	 *
+	 * @return string
+	 */
+	function get_term_parents(
+		$id,
+		$taxonomy,
+		$link = false,
+		$separator = '/',
+		$nicename = false,
+		$visited = array()
+	) {
+		$chain = '';
+		$parent = get_term( $id, $taxonomy );
+		if ( is_wp_error( $parent ) ) {
+			return $parent;
+		}
 
-        if ( $nicename ) {
-            $name = $parent->slug;
-        }
-        else {
-            $name = $parent->cat_name;
-        }
+		if ( $nicename ) {
+			$name = $parent->slug;
+		}
+		else {
+			$name = $parent->cat_name;
+		}
 
-        if ( $parent->parent && ( $parent->parent != $parent->term_id ) && ! in_array( $parent->parent, $visited ) ) {
-            $visited[] = $parent->parent;
-            $chain .= get_term_parents( $parent->parent, $taxonomy, $link, $separator, $nicename, $visited );
-        }
+		if ( $parent->parent && ( $parent->parent != $parent->term_id ) && ! in_array( $parent->parent, $visited ) ) {
+			$visited[] = $parent->parent;
+			$chain .= get_term_parents( $parent->parent, $taxonomy, $link, $separator, $nicename, $visited );
+		}
 
-        if ( $link ) {
-            $chain .= '<a href="' . get_term_link( $parent->term_id, $taxonomy ) . '" title="' . esc_attr( sprintf( __( 'View all posts in %s' ), $parent->name ) ) . '">' . $name . '</a>' . $separator;
-        }
-        else {
-            $chain .= $name . $separator;
-        }
+		if ( $link ) {
+			$chain .= '<a href="' . get_term_link( $parent->term_id, $taxonomy ) . '" title="' . esc_attr( sprintf( __( 'View all posts in %s' ), $parent->name ) ) . '">' . $name . '</a>' . $separator;
+		}
+		else {
+			$chain .= $name . $separator;
+		}
 
-        return $chain;
-    }
+		return $chain;
+	}
 
 }
 
@@ -445,48 +445,48 @@ if ( ! function_exists( 'get_term_parents' ) ) {
  */
 if ( ! function_exists( 'enable_permalinks_settings' ) ) {
 
-    // process the $_POST variable after all settings have been
-    // registered so they are whitelisted
-    add_action( 'admin_init', 'enable_permalinks_settings', 300 );
+	// process the $_POST variable after all settings have been
+	// registered so they are whitelisted
+	add_action( 'admin_init', 'enable_permalinks_settings', 300 );
 
-    function enable_permalinks_settings() {
-        global $new_whitelist_options;
+	function enable_permalinks_settings() {
+		global $new_whitelist_options;
 
-        // save hook for permalinks page
-        if ( isset( $_POST['permalink_structure'] ) || isset( $_POST['category_base'] ) ) {
-            check_admin_referer( 'update-permalink' );
+		// save hook for permalinks page
+		if ( isset( $_POST['permalink_structure'] ) || isset( $_POST['category_base'] ) ) {
+			check_admin_referer( 'update-permalink' );
 
-            $option_page = 'permalink';
+			$option_page = 'permalink';
 
-            $capability = 'manage_options';
-            $capability = apply_filters( "option_page_capability_{$option_page}", $capability );
+			$capability = 'manage_options';
+			$capability = apply_filters( "option_page_capability_{$option_page}", $capability );
 
-            if ( ! current_user_can( $capability ) ) {
-                wp_die( __( 'Cheatin&#8217; uh?' ) );
-            }
+			if ( ! current_user_can( $capability ) ) {
+				wp_die( __( 'Cheatin&#8217; uh?' ) );
+			}
 
-            // get extra permalink options
-            $options = $new_whitelist_options[ $option_page ];
+			// get extra permalink options
+			$options = $new_whitelist_options[ $option_page ];
 
-            if ( $options ) {
-                foreach ( $options as $option ) {
-                    $option = trim( $option );
-                    $value = null;
-                    if ( isset( $_POST[ $option ] ) ) {
-                        $value = $_POST[ $option ];
-                    }
-                    if ( ! is_array( $value ) ) {
-                        $value = trim( $value );
-                    }
-                    $value = stripslashes_deep( $value );
-                    update_option( $option, $value );
-                }
-            }
+			if ( $options ) {
+				foreach ( $options as $option ) {
+					$option = trim( $option );
+					$value = null;
+					if ( isset( $_POST[ $option ] ) ) {
+						$value = $_POST[ $option ];
+					}
+					if ( ! is_array( $value ) ) {
+						$value = trim( $value );
+					}
+					$value = stripslashes_deep( $value );
+					update_option( $option, $value );
+				}
+			}
 
-            /**
-             *  Handle settings errors
-             */
-            set_transient( 'settings_errors', get_settings_errors(), 30 );
-        }
-    }
+			/**
+			 *  Handle settings errors
+			 */
+			set_transient( 'settings_errors', get_settings_errors(), 30 );
+		}
+	}
 }

--- a/wp-permastructure.php
+++ b/wp-permastructure.php
@@ -3,7 +3,7 @@
 Plugin Name: WP Permastructure
 Plugin URI: https://github.com/interconnectit/wp-permastructure
 Description: Adds the ability to define permalink structures for any custom post type using rewrite tags.
-Version: 1.5.0
+Version: 1.5.1
 Author: Robert O'Rourke
 Author URI: http://interconnectit.com
 License: GPLv2 or later
@@ -37,10 +37,6 @@ License: GPLv2 or later
  * 1.1: Fixed problem with WP walk_dirs and using %category% in permalink - overly greedy match
  * 1.0: Initial import
  */
-
-if ( class_exists( 'wp_permastructure' ) ) {
-	return;
-}
 
 add_action( 'init', array( 'wp_permastructure', 'instance' ), 0 );
 

--- a/wp-permastructure.php
+++ b/wp-permastructure.php
@@ -38,404 +38,406 @@ License: GPLv2 or later
  * 1.0: Initial import
  */
 
-if ( !class_exists( 'wp_permastructure' ) ) {
+if ( class_exists( 'wp_permastructure' ) ) {
+	return;
+}
 
-	add_action( 'init', array( 'wp_permastructure', 'instance' ), 0 );
+add_action( 'init', array( 'wp_permastructure', 'instance' ), 0 );
 
-	class wp_permastructure {
+class wp_permastructure {
 
-		public $settings_section = 'wp_permastructure';
+	public $settings_section = 'wp_permastructure';
 
-		/**
-		 * @var protect endpoints from being vaped if a category/tag slug is set
-		 */
-		protected $endpoints;
+	/**
+	 * @var protect endpoints from being vaped if a category/tag slug is set
+	 */
+	protected $endpoints;
 
-		/**
-		 * Reusable object instance.
-		 *
-		 * @type object
-		 */
-		protected static $instance = null;
+	/**
+	 * Reusable object instance.
+	 *
+	 * @type object
+	 */
+	protected static $instance = null;
 
-		/**
-		 * Creates a new instance. Called on 'init'.
-		 * May be used to access class methods from outside.
-		 *
-		 * @see    __construct()
-		 * @return void
-		 */
-		public static function instance() {
-			null === self:: $instance AND self:: $instance = new self;
+	/**
+	 * Creates a new instance. Called on 'init'.
+	 * May be used to access class methods from outside.
+	 *
+	 * @see    __construct()
+	 * @return void
+	 */
+	public static function instance() {
+		null === self:: $instance AND self:: $instance = new self;
 
-			return self:: $instance;
-		}
-
-
-		public function __construct() {
-
-			// Late init to protect endpoints
-			add_action( 'init', array( $this, 'late_init' ), 999 );
-
-			// Settings fields on permalinks page
-			add_action( 'admin_init', array( $this, 'admin_init' ) );
-
-			// add our new peramstructs to the rewrite rules
-			add_filter( 'post_rewrite_rules', array( $this, 'add_permastructs' ) );
-
-			// parse the generated links - enable custom taxonomies for built in post links
-			add_filter( 'post_link', array( $this, 'parse_permalinks' ), 10, 3 );
-			add_filter( 'post_type_link', array( $this, 'parse_permalinks' ), 10, 4 );
-
-			// that's it!
-
-		}
+		return self:: $instance;
+	}
 
 
-		public function late_init() {
-			global $wp_rewrite;
-			$this->endpoints = $wp_rewrite->endpoints;
-		}
+	public function __construct() {
+
+		// Late init to protect endpoints
+		add_action( 'init', array( $this, 'late_init' ), 999 );
+
+		// Settings fields on permalinks page
+		add_action( 'admin_init', array( $this, 'admin_init' ) );
+
+		// add our new peramstructs to the rewrite rules
+		add_filter( 'post_rewrite_rules', array( $this, 'add_permastructs' ) );
+
+		// parse the generated links - enable custom taxonomies for built in post links
+		add_filter( 'post_link', array( $this, 'parse_permalinks' ), 10, 3 );
+		add_filter( 'post_type_link', array( $this, 'parse_permalinks' ), 10, 4 );
+
+		// that's it!
+
+	}
 
 
-		/**
-		 * Add the settings UI
-		 */
-		public function admin_init() {
+	public function late_init() {
+		global $wp_rewrite;
+		$this->endpoints = $wp_rewrite->endpoints;
+	}
 
-			add_settings_section(
+
+	/**
+	 * Add the settings UI
+	 */
+	public function admin_init() {
+
+		add_settings_section(
+			$this->settings_section,
+			__( 'Custom post type permalink settings' ),
+			array( $this, 'settings_section' ),
+			'permalink'
+		);
+
+		foreach ( get_post_types( array( '_builtin' => false, 'public' => true ), 'objects' ) as $type ) {
+			$id = $type->name . '_permalink_structure';
+
+			register_setting( 'permalink', $id, array( $this, 'sanitize_permalink' ) );
+			add_settings_field(
+				$id,
+				__( $type->label . ' permalink structure' ),
+				array( $this, 'permalink_field' ),
+				'permalink',
 				$this->settings_section,
-				__( 'Custom post type permalink settings' ),
-				array( $this, 'settings_section' ),
-				'permalink'
+				array( 'id' => $id )
 			);
-
-			foreach ( get_post_types( array( '_builtin' => false, 'public' => true ), 'objects' ) as $type ) {
-				$id = $type->name . '_permalink_structure';
-
-				register_setting( 'permalink', $id, array( $this, 'sanitize_permalink' ) );
-				add_settings_field(
-					$id,
-					__( $type->label . ' permalink structure' ),
-					array( $this, 'permalink_field' ),
-					'permalink',
-					$this->settings_section,
-					array( 'id' => $id )
-				);
-			}
-
-		}
-
-
-		public function settings_section() {
-
-		}
-
-
-		public function permalink_field( $args ) {
-			echo '<input type="text" class="regular-text code" value="' . esc_attr( get_option( $args[ 'id' ] ) ) . '" id="' . $args[ 'id' ] . '" name="' . $args[ 'id' ] . '" />';
-		}
-
-
-		/**
-		 * Runs a simple sanitisation of the custom post type permalink structures
-		 * and adds an error if no post ID or post name present
-		 *
-		 * @param string $permalink The permalink structure
-		 *
-		 * @return string    Sanitised permalink structure
-		 */
-		public function sanitize_permalink( $permalink ) {
-			if ( !empty( $permalink ) && !preg_match( '/%(post_id|postname)%/', $permalink ) ) {
-				add_settings_error( 'permalink_structure', 10, __( 'Permalink structures must contain at least the <code>%post_id%</code> or <code>%postname%</code>.' ) );
-			}
-
-			$filtered = wp_check_invalid_utf8( $permalink );
-
-			if ( strpos( $filtered, '<' ) !== false ) {
-				$filtered = wp_pre_kses_less_than( $filtered );
-				// This will strip extra whitespace for us.
-				$filtered = wp_strip_all_tags( $filtered, true );
-			}
-			else {
-				$filtered = trim( preg_replace( '/[\r\n\t ]+/', ' ', $filtered ) );
-			}
-
-			return preg_replace( '/[^a-zA-Z0-9\/\%\._-]*/', '', $filtered );
-		}
-
-
-		/**
-		 * This function removes unnecessary rules and adds in the new rules
-		 *
-		 * @param array $rules The rewrite rules array for post permalinks
-		 *
-		 * @return array    The modified rules array
-		 */
-		public function add_permastructs( $rules ) {
-			global $wp_rewrite;
-
-			// restore endpoints
-			if ( empty( $wp_rewrite->endpoints ) && !empty( $this->endpoints ) ) {
-				$wp_rewrite->endpoints = $this->endpoints;
-			}
-
-			$permastruct = $wp_rewrite->permalink_structure;
-			$permastructs = array( $permastruct => array( 'post' ) );
-
-			// force page rewrite to bottom
-			$wp_rewrite->use_verbose_page_rules = false;
-
-			// get permastructs foreach custom post type and group any that use the same struct
-			foreach ( get_post_types( array( '_builtin' => false, 'public' => true ), 'objects' ) as $type ) {
-				// add/override the custom permalink structure if set in options
-				$post_type_permastruct = get_option( $type->name . '_permalink_structure' );
-				if ( $post_type_permastruct && !empty( $post_type_permastruct ) ) {
-					if ( !is_array( $type->rewrite ) ) {
-						$type->rewrite = array();
-					}
-					$type->rewrite[ 'permastruct' ] = $post_type_permastruct;
-				}
-
-				// check we have a custom permalink structure
-				if ( !is_array( $type->rewrite ) || !isset( $type->rewrite[ 'permastruct' ] ) ) {
-					continue;
-				}
-
-				// remove default struct rules
-				add_filter( $type->name . '_rewrite_rules', function( $rules ) {
-					return array();
-				}, 11 );
-
-				if ( !isset( $permastructs[ $type->rewrite[ 'permastruct' ] ] ) ) {
-					$permastructs[ $type->rewrite[ 'permastruct' ] ] = array();
-				}
-
-				$permastructs[ $type->rewrite[ 'permastruct' ] ][] = $type->name;
-			}
-
-			$rules = array();
-
-			// add our permastructs scoped to the post types - overwriting any keys that already exist
-			foreach ( $permastructs as $struct => $post_types ) {
-
-				// if a struct is %postname% only then we need page rules first - if not found wp tries again with later rules
-				if ( preg_match( '/^\/?%postname%\/?$/', $struct ) ) {
-					$wp_rewrite->use_verbose_page_rules = true;
-				}
-
-				// get rewrite rules without walking dirs
-				$post_type_rules_temp = $wp_rewrite->generate_rewrite_rules( $struct, EP_PERMALINK, false, true, false, false, true );
-				foreach ( $post_type_rules_temp as $regex => $query ) {
-					if ( preg_match( '/(&|\?)(cpage|attachment|p|name|pagename)=/', $query ) ) {
-						$post_type_query = ( count( $post_types ) < 2 ? '&post_type=' . $post_types[ 0 ] : '&post_type[]=' . join( '&post_type[]=', array_unique( $post_types ) ) );
-						$rules[ $regex ] = $query . ( preg_match( '/(&|\?)(attachment|pagename)=/', $query ) ? '' : $post_type_query );
-						// Ensure permalinks that match a custom taxonomy path don't get swallowed.
-						$wp_rewrite->extra_rules_top[ $regex ] = $rules[ $regex ];
-					}
-					else {
-						unset( $rules[ $regex ] );
-					}
-				}
-
-			}
-
-			return $rules;
-		}
-
-
-		/**
-		 * Generic version of standard permalink parsing function. Adds support for
-		 * custom taxonomies as well as the standard %author% etc...
-		 *
-		 * @param string  $post_link The post URL
-		 * @param WP_Post $post The post object
-		 * @param bool    $leavename Passed to pre_post_link filter
-		 * @param bool    $sample Used in admin if generating an example permalink
-		 *
-		 * @return string    The parsed permalink
-		 */
-		public function parse_permalinks( $post_link, $post, $leavename, $sample = false ) {
-			// Yoast Sitemap plug-in doesn't pass a WP_Post object causing a fatal, so we'll check for it and return.
-			if ( !is_a( $post, 'WP_Post' ) ) {
-				return $post_link;
-			}
-
-			// Make a stupid request and we'll do nothing.
-			if ( !post_type_exists( $post->post_type ) ) {
-				return $post_link;
-			}
-
-			$rewritecode = array(
-				'%year%',
-				'%monthnum%',
-				'%day%',
-				'%hour%',
-				'%minute%',
-				'%second%',
-				$leavename ? '' : '%postname%',
-				'%post_id%',
-				'%author%',
-				$leavename ? '' : '%pagename%',
-			);
-
-			$taxonomies = get_object_taxonomies( $post->post_type );
-
-			foreach ( $taxonomies as $taxonomy ) {
-				$rewritecode[] = '%' . $taxonomy . '%';
-			}
-
-			if ( is_object( $post ) && isset( $post->filter ) && 'sample' == $post->filter ) {
-				$sample = true;
-			}
-
-			$post_type = get_post_type_object( $post->post_type );
-			$permastruct = get_option( $post_type->name . '_permalink_structure' );
-
-			if ( empty( $permastruct ) && $post->post_type === 'post' ) {
-				$permastruct = get_option( 'permalink_structure' );
-			}
-
-			// prefer option over default
-			if ( !empty( $permastruct ) ) {
-				$permalink = $permastruct;
-			}
-			elseif ( isset( $post_type->rewrite[ 'permastruct' ] ) && !empty( $post_type->rewrite[ 'permastruct' ] ) ) {
-				$permalink = $post_type->rewrite[ 'permastruct' ];
-			}
-			else {
-				return $post_link;
-			}
-
-			$permalink = apply_filters( 'pre_post_link', $permalink, $post, $leavename );
-
-			if ( '' != $permalink && !in_array( $post->post_status, array( 'draft', 'pending', 'auto-draft' ) ) ) {
-				$unixtime = strtotime( $post->post_date );
-
-				// add ability to use any taxonomies in post type permastruct
-				$replace_terms = array();
-				foreach ( $taxonomies as $taxonomy ) {
-					$term = '';
-					$taxonomy_object = get_taxonomy( $taxonomy );
-					if ( strpos( $permalink, '%' . $taxonomy . '%' ) !== false ) {
-						$terms = get_the_terms( $post->ID, $taxonomy );
-						if ( $terms && ! is_wp_error( $terms ) ) {
-							if ( function_exists( 'wp_list_sort' ) ) {
-								$terms = wp_list_sort( $terms, 'term_id', 'ASC' );  // order by term_id ASC
-							} else {
-								usort( $terms, '_usort_terms_by_ID' ); // order by term_id ASC
-							}
-
-							/**
-							 * Filter the term that gets used in the `$tax` permalink token.
-							 *
-							 * @param WP_Term  $term  The `$tax` term to use in the permalink.
-							 * @param array    $terms Array of all `$tax` terms associated with the post.
-							 * @param WP_Post  $post  The post in question.
-							 */
-							$term_object = apply_filters( "post_link_{$taxonomy}", reset( $terms ), $terms, $post );
-
-							$term = $term_object->slug;
-							if ( $taxonomy_object->hierarchical && $parent = $term_object->parent ) {
-								$term = get_term_parents( $parent, $taxonomy, false, '/', true ) . $term;
-							}
-						}
-						// show default category in permalinks, without
-						// having to assign it explicitly
-						if ( empty( $term ) && $taxonomy == 'category' ) {
-							$default_category = get_category( get_option( 'default_category' ) );
-							$term = is_wp_error( $default_category ) ? '' : $default_category->slug;
-						}
-					}
-					$replace_terms[ $taxonomy ] = $term;
-				}
-
-				$author = '';
-				if ( strpos( $permalink, '%author%' ) !== false ) {
-					$authordata = get_userdata( $post->post_author );
-					$author = $authordata->user_nicename;
-				}
-
-				$date = explode( " ", date( 'Y m d H i s', $unixtime ) );
-				$rewritereplace =
-					array(
-						$date[ 0 ],
-						$date[ 1 ],
-						$date[ 2 ],
-						$date[ 3 ],
-						$date[ 4 ],
-						$date[ 5 ],
-						$post->post_name,
-						$post->ID,
-						$author,
-						$post->post_name,
-					);
-				foreach ( $taxonomies as $taxonomy ) {
-					$rewritereplace[] = $replace_terms[ $taxonomy ];
-				}
-				$permalink = home_url( str_replace( $rewritecode, $rewritereplace, $permalink ) );
-				$permalink = user_trailingslashit( $permalink, 'single' );
-			}
-			else { // if they're not using the fancy permalink option
-				$permalink = home_url( '?p=' . $post->ID );
-			}
-
-			return $permalink;
 		}
 
 	}
+
+
+	public function settings_section() {
+
+	}
+
+
+	public function permalink_field( $args ) {
+		echo '<input type="text" class="regular-text code" value="' . esc_attr( get_option( $args[ 'id' ] ) ) . '" id="' . $args[ 'id' ] . '" name="' . $args[ 'id' ] . '" />';
+	}
+
+
+	/**
+	 * Runs a simple sanitisation of the custom post type permalink structures
+	 * and adds an error if no post ID or post name present
+	 *
+	 * @param string $permalink The permalink structure
+	 *
+	 * @return string    Sanitised permalink structure
+	 */
+	public function sanitize_permalink( $permalink ) {
+		if ( !empty( $permalink ) && !preg_match( '/%(post_id|postname)%/', $permalink ) ) {
+			add_settings_error( 'permalink_structure', 10, __( 'Permalink structures must contain at least the <code>%post_id%</code> or <code>%postname%</code>.' ) );
+		}
+
+		$filtered = wp_check_invalid_utf8( $permalink );
+
+		if ( strpos( $filtered, '<' ) !== false ) {
+			$filtered = wp_pre_kses_less_than( $filtered );
+			// This will strip extra whitespace for us.
+			$filtered = wp_strip_all_tags( $filtered, true );
+		}
+		else {
+			$filtered = trim( preg_replace( '/[\r\n\t ]+/', ' ', $filtered ) );
+		}
+
+		return preg_replace( '/[^a-zA-Z0-9\/\%\._-]*/', '', $filtered );
+	}
+
+
+	/**
+	 * This function removes unnecessary rules and adds in the new rules
+	 *
+	 * @param array $rules The rewrite rules array for post permalinks
+	 *
+	 * @return array    The modified rules array
+	 */
+	public function add_permastructs( $rules ) {
+		global $wp_rewrite;
+
+		// restore endpoints
+		if ( empty( $wp_rewrite->endpoints ) && !empty( $this->endpoints ) ) {
+			$wp_rewrite->endpoints = $this->endpoints;
+		}
+
+		$permastruct = $wp_rewrite->permalink_structure;
+		$permastructs = array( $permastruct => array( 'post' ) );
+
+		// force page rewrite to bottom
+		$wp_rewrite->use_verbose_page_rules = false;
+
+		// get permastructs foreach custom post type and group any that use the same struct
+		foreach ( get_post_types( array( '_builtin' => false, 'public' => true ), 'objects' ) as $type ) {
+			// add/override the custom permalink structure if set in options
+			$post_type_permastruct = get_option( $type->name . '_permalink_structure' );
+			if ( $post_type_permastruct && !empty( $post_type_permastruct ) ) {
+				if ( !is_array( $type->rewrite ) ) {
+					$type->rewrite = array();
+				}
+				$type->rewrite[ 'permastruct' ] = $post_type_permastruct;
+			}
+
+			// check we have a custom permalink structure
+			if ( !is_array( $type->rewrite ) || !isset( $type->rewrite[ 'permastruct' ] ) ) {
+				continue;
+			}
+
+			// remove default struct rules
+			add_filter( $type->name . '_rewrite_rules', function( $rules ) {
+				return array();
+			}, 11 );
+
+			if ( !isset( $permastructs[ $type->rewrite[ 'permastruct' ] ] ) ) {
+				$permastructs[ $type->rewrite[ 'permastruct' ] ] = array();
+			}
+
+			$permastructs[ $type->rewrite[ 'permastruct' ] ][] = $type->name;
+		}
+
+		$rules = array();
+
+		// add our permastructs scoped to the post types - overwriting any keys that already exist
+		foreach ( $permastructs as $struct => $post_types ) {
+
+			// if a struct is %postname% only then we need page rules first - if not found wp tries again with later rules
+			if ( preg_match( '/^\/?%postname%\/?$/', $struct ) ) {
+				$wp_rewrite->use_verbose_page_rules = true;
+			}
+
+			// get rewrite rules without walking dirs
+			$post_type_rules_temp = $wp_rewrite->generate_rewrite_rules( $struct, EP_PERMALINK, false, true, false, false, true );
+			foreach ( $post_type_rules_temp as $regex => $query ) {
+				if ( preg_match( '/(&|\?)(cpage|attachment|p|name|pagename)=/', $query ) ) {
+					$post_type_query = ( count( $post_types ) < 2 ? '&post_type=' . $post_types[ 0 ] : '&post_type[]=' . join( '&post_type[]=', array_unique( $post_types ) ) );
+					$rules[ $regex ] = $query . ( preg_match( '/(&|\?)(attachment|pagename)=/', $query ) ? '' : $post_type_query );
+					// Ensure permalinks that match a custom taxonomy path don't get swallowed.
+					$wp_rewrite->extra_rules_top[ $regex ] = $rules[ $regex ];
+				}
+				else {
+					unset( $rules[ $regex ] );
+				}
+			}
+
+		}
+
+		return $rules;
+	}
+
+
+	/**
+	 * Generic version of standard permalink parsing function. Adds support for
+	 * custom taxonomies as well as the standard %author% etc...
+	 *
+	 * @param string  $post_link The post URL
+	 * @param WP_Post $post The post object
+	 * @param bool    $leavename Passed to pre_post_link filter
+	 * @param bool    $sample Used in admin if generating an example permalink
+	 *
+	 * @return string    The parsed permalink
+	 */
+	public function parse_permalinks( $post_link, $post, $leavename, $sample = false ) {
+		// Yoast Sitemap plug-in doesn't pass a WP_Post object causing a fatal, so we'll check for it and return.
+		if ( !is_a( $post, 'WP_Post' ) ) {
+			return $post_link;
+		}
+
+		// Make a stupid request and we'll do nothing.
+		if ( !post_type_exists( $post->post_type ) ) {
+			return $post_link;
+		}
+
+		$rewritecode = array(
+			'%year%',
+			'%monthnum%',
+			'%day%',
+			'%hour%',
+			'%minute%',
+			'%second%',
+			$leavename ? '' : '%postname%',
+			'%post_id%',
+			'%author%',
+			$leavename ? '' : '%pagename%',
+		);
+
+		$taxonomies = get_object_taxonomies( $post->post_type );
+
+		foreach ( $taxonomies as $taxonomy ) {
+			$rewritecode[] = '%' . $taxonomy . '%';
+		}
+
+		if ( is_object( $post ) && isset( $post->filter ) && 'sample' == $post->filter ) {
+			$sample = true;
+		}
+
+		$post_type = get_post_type_object( $post->post_type );
+		$permastruct = get_option( $post_type->name . '_permalink_structure' );
+
+		if ( empty( $permastruct ) && $post->post_type === 'post' ) {
+			$permastruct = get_option( 'permalink_structure' );
+		}
+
+		// prefer option over default
+		if ( !empty( $permastruct ) ) {
+			$permalink = $permastruct;
+		}
+		elseif ( isset( $post_type->rewrite[ 'permastruct' ] ) && !empty( $post_type->rewrite[ 'permastruct' ] ) ) {
+			$permalink = $post_type->rewrite[ 'permastruct' ];
+		}
+		else {
+			return $post_link;
+		}
+
+		$permalink = apply_filters( 'pre_post_link', $permalink, $post, $leavename );
+
+		if ( '' != $permalink && !in_array( $post->post_status, array( 'draft', 'pending', 'auto-draft' ) ) ) {
+			$unixtime = strtotime( $post->post_date );
+
+			// add ability to use any taxonomies in post type permastruct
+			$replace_terms = array();
+			foreach ( $taxonomies as $taxonomy ) {
+				$term = '';
+				$taxonomy_object = get_taxonomy( $taxonomy );
+				if ( strpos( $permalink, '%' . $taxonomy . '%' ) !== false ) {
+					$terms = get_the_terms( $post->ID, $taxonomy );
+					if ( $terms && ! is_wp_error( $terms ) ) {
+						if ( function_exists( 'wp_list_sort' ) ) {
+							$terms = wp_list_sort( $terms, 'term_id', 'ASC' );  // order by term_id ASC
+						} else {
+							usort( $terms, '_usort_terms_by_ID' ); // order by term_id ASC
+						}
+
+						/**
+						 * Filter the term that gets used in the `$tax` permalink token.
+						 *
+						 * @param WP_Term  $term  The `$tax` term to use in the permalink.
+						 * @param array    $terms Array of all `$tax` terms associated with the post.
+						 * @param WP_Post  $post  The post in question.
+						 */
+						$term_object = apply_filters( "post_link_{$taxonomy}", reset( $terms ), $terms, $post );
+
+						$term = $term_object->slug;
+						if ( $taxonomy_object->hierarchical && $parent = $term_object->parent ) {
+							$term = get_term_parents( $parent, $taxonomy, false, '/', true ) . $term;
+						}
+					}
+					// show default category in permalinks, without
+					// having to assign it explicitly
+					if ( empty( $term ) && $taxonomy == 'category' ) {
+						$default_category = get_category( get_option( 'default_category' ) );
+						$term = is_wp_error( $default_category ) ? '' : $default_category->slug;
+					}
+				}
+				$replace_terms[ $taxonomy ] = $term;
+			}
+
+			$author = '';
+			if ( strpos( $permalink, '%author%' ) !== false ) {
+				$authordata = get_userdata( $post->post_author );
+				$author = $authordata->user_nicename;
+			}
+
+			$date = explode( " ", date( 'Y m d H i s', $unixtime ) );
+			$rewritereplace =
+				array(
+					$date[ 0 ],
+					$date[ 1 ],
+					$date[ 2 ],
+					$date[ 3 ],
+					$date[ 4 ],
+					$date[ 5 ],
+					$post->post_name,
+					$post->ID,
+					$author,
+					$post->post_name,
+				);
+			foreach ( $taxonomies as $taxonomy ) {
+				$rewritereplace[] = $replace_terms[ $taxonomy ];
+			}
+			$permalink = home_url( str_replace( $rewritecode, $rewritereplace, $permalink ) );
+			$permalink = user_trailingslashit( $permalink, 'single' );
+		}
+		else { // if they're not using the fancy permalink option
+			$permalink = home_url( '?p=' . $post->ID );
+		}
+
+		return $permalink;
+	}
+
+}
 
 }
 
 if ( ! function_exists( 'get_term_parents' ) ) {
 
-	/**
-	 * Retrieve term parents with separator.
-	 *
-	 * @param int    $id Term ID.
-	 * @param string $taxonomy The taxonomy the term belongs to.
-	 * @param bool   $link Optional, default is false. Whether to format with link.
-	 * @param string $separator Optional, default is '/'. How to separate categories.
-	 * @param bool   $nicename Optional, default is false. Whether to use nice name for display.
-	 * @param array  $visited Optional. Already linked to categories to prevent duplicates.
-	 *
-	 * @return string
-	 */
-	function get_term_parents(
-		$id,
-		$taxonomy,
-		$link = false,
-		$separator = '/',
-		$nicename = false,
-		$visited = array()
-	) {
-		$chain = '';
-		$parent = get_term( $id, $taxonomy );
-		if ( is_wp_error( $parent ) ) {
-			return $parent;
-		}
-
-		if ( $nicename ) {
-			$name = $parent->slug;
-		}
-		else {
-			$name = $parent->cat_name;
-		}
-
-		if ( $parent->parent && ( $parent->parent != $parent->term_id ) && ! in_array( $parent->parent, $visited ) ) {
-			$visited[] = $parent->parent;
-			$chain .= get_term_parents( $parent->parent, $taxonomy, $link, $separator, $nicename, $visited );
-		}
-
-		if ( $link ) {
-			$chain .= '<a href="' . get_term_link( $parent->term_id, $taxonomy ) . '" title="' . esc_attr( sprintf( __( 'View all posts in %s' ), $parent->name ) ) . '">' . $name . '</a>' . $separator;
-		}
-		else {
-			$chain .= $name . $separator;
-		}
-
-		return $chain;
+/**
+ * Retrieve term parents with separator.
+ *
+ * @param int    $id Term ID.
+ * @param string $taxonomy The taxonomy the term belongs to.
+ * @param bool   $link Optional, default is false. Whether to format with link.
+ * @param string $separator Optional, default is '/'. How to separate categories.
+ * @param bool   $nicename Optional, default is false. Whether to use nice name for display.
+ * @param array  $visited Optional. Already linked to categories to prevent duplicates.
+ *
+ * @return string
+ */
+function get_term_parents(
+	$id,
+	$taxonomy,
+	$link = false,
+	$separator = '/',
+	$nicename = false,
+	$visited = array()
+) {
+	$chain = '';
+	$parent = get_term( $id, $taxonomy );
+	if ( is_wp_error( $parent ) ) {
+		return $parent;
 	}
+
+	if ( $nicename ) {
+		$name = $parent->slug;
+	}
+	else {
+		$name = $parent->cat_name;
+	}
+
+	if ( $parent->parent && ( $parent->parent != $parent->term_id ) && ! in_array( $parent->parent, $visited ) ) {
+		$visited[] = $parent->parent;
+		$chain .= get_term_parents( $parent->parent, $taxonomy, $link, $separator, $nicename, $visited );
+	}
+
+	if ( $link ) {
+		$chain .= '<a href="' . get_term_link( $parent->term_id, $taxonomy ) . '" title="' . esc_attr( sprintf( __( 'View all posts in %s' ), $parent->name ) ) . '">' . $name . '</a>' . $separator;
+	}
+	else {
+		$chain .= $name . $separator;
+	}
+
+	return $chain;
+}
 
 }
 
@@ -445,48 +447,47 @@ if ( ! function_exists( 'get_term_parents' ) ) {
  */
 if ( ! function_exists( 'enable_permalinks_settings' ) ) {
 
-	// process the $_POST variable after all settings have been
-	// registered so they are whitelisted
-	add_action( 'admin_init', 'enable_permalinks_settings', 300 );
+// process the $_POST variable after all settings have been
+// registered so they are whitelisted
+add_action( 'admin_init', 'enable_permalinks_settings', 300 );
 
-	function enable_permalinks_settings() {
-		global $new_whitelist_options;
+function enable_permalinks_settings() {
+	global $new_whitelist_options;
 
-		// save hook for permalinks page
-		if ( isset( $_POST['permalink_structure'] ) || isset( $_POST['category_base'] ) ) {
-			check_admin_referer( 'update-permalink' );
+	// save hook for permalinks page
+	if ( isset( $_POST['permalink_structure'] ) || isset( $_POST['category_base'] ) ) {
+		check_admin_referer( 'update-permalink' );
 
-			$option_page = 'permalink';
+		$option_page = 'permalink';
 
-			$capability = 'manage_options';
-			$capability = apply_filters( "option_page_capability_{$option_page}", $capability );
+		$capability = 'manage_options';
+		$capability = apply_filters( "option_page_capability_{$option_page}", $capability );
 
-			if ( ! current_user_can( $capability ) ) {
-				wp_die( __( 'Cheatin&#8217; uh?' ) );
-			}
-
-			// get extra permalink options
-			$options = $new_whitelist_options[ $option_page ];
-
-			if ( $options ) {
-				foreach ( $options as $option ) {
-					$option = trim( $option );
-					$value = null;
-					if ( isset( $_POST[ $option ] ) ) {
-						$value = $_POST[ $option ];
-					}
-					if ( ! is_array( $value ) ) {
-						$value = trim( $value );
-					}
-					$value = stripslashes_deep( $value );
-					update_option( $option, $value );
-				}
-			}
-
-			/**
-			 *  Handle settings errors
-			 */
-			set_transient( 'settings_errors', get_settings_errors(), 30 );
+		if ( ! current_user_can( $capability ) ) {
+			wp_die( __( 'Cheatin&#8217; uh?' ) );
 		}
+
+		// get extra permalink options
+		$options = $new_whitelist_options[ $option_page ];
+
+		if ( $options ) {
+			foreach ( $options as $option ) {
+				$option = trim( $option );
+				$value = null;
+				if ( isset( $_POST[ $option ] ) ) {
+					$value = $_POST[ $option ];
+				}
+				if ( ! is_array( $value ) ) {
+					$value = trim( $value );
+				}
+				$value = stripslashes_deep( $value );
+				update_option( $option, $value );
+			}
+		}
+
+		/**
+		 *  Handle settings errors
+		 */
+		set_transient( 'settings_errors', get_settings_errors(), 30 );
 	}
 }


### PR DESCRIPTION
Hey, there are couple things added here:

 * Support for filtering the terms used in a %taxonomy% replacement
 * Try to ensure a `WP_Post` object in `post_type_link` filter before bailing
 * Use non deprecated function to sort terms if available

Props to @shadyvb and @mmaton

Fixes #5 